### PR TITLE
Adding implementation of fiveg_n3 interface in the UPF

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,10 +36,24 @@ jobs:
       charm-file-name: "sdcore-upf_ubuntu-22.04-amd64.charm"
     secrets: inherit
 
+  lib-needs-publishing:
+    runs-on: ubuntu-22.04
+    outputs:
+      needs-publishing: ${{ steps.changes.outputs.fiveg_n3 }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            fiveg_n3:
+              - 'lib/charms/sdcore_upf/v0/fiveg_n3.py'
+
   publish-lib:
     name: Publish Lib
     needs:
-      [ publish-charm ]
+      - publish-charm
+      - lib-needs-publishing
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@main
     with:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -57,6 +57,8 @@ storage:
     minimum-size: 1M
 
 provides:
+  fiveg_n3:
+    interface: fiveg_n3
   metrics-endpoint:
     interface: prometheus_scrape
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ ops
 jinja2
 lightkube
 lightkube-models
+pydantic
+pytest-interface-tester

--- a/src/charm.py
+++ b/src/charm.py
@@ -116,6 +116,8 @@ class UPFOperatorCharm(CharmBase):
         Args:
             event: Juju event
         """
+        if not self.unit.is_leader():
+            return
         if not self._access_ip_config_is_valid():
             self.unit.status = BlockedStatus("Invalid `access-ip` config provided")
             return
@@ -125,11 +127,10 @@ class UPFOperatorCharm(CharmBase):
             logger.info("No `fiveg_n3` relations found.")
             return
         for fiveg_n3_relation in fiveg_n3_relations:
-            if self._get_upf_ip_from_relation_data_bag(fiveg_n3_relation) != upf_access_ip_address:
-                self.fiveg_n3_provider.publish_upf_information(
-                    relation_id=fiveg_n3_relation.id,
-                    upf_ip_address=upf_access_ip_address,
-                )
+            self.fiveg_n3_provider.publish_upf_information(
+                relation_id=fiveg_n3_relation.id,
+                upf_ip_address=upf_access_ip_address,
+            )
 
     def _network_annotations_from_config(self) -> list[NetworkAnnotation]:
         """Returns the list of network annotation to be added to the charm statefulset.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -515,3 +515,72 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._configure(event=Mock())
 
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
+
+    @patch("charms.sdcore_upf.v0.fiveg_n3.N3Provides.publish_upf_information")
+    def test_given_fiveg_n3_relation_created_when_fiveg_n3_request_then_upf_ip_address_is_published(  # noqa: E501
+        self, patched_publish_upf_information
+    ):
+        self.harness.set_leader(is_leader=True)
+        test_upf_access_ip_cidr = "1.2.3.4/21"
+        self.harness.update_config(key_values={"access-ip": test_upf_access_ip_cidr})
+
+        n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
+        self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
+
+        patched_publish_upf_information.assert_called_once_with(
+            relation_id=n3_relation_id, upf_ip_address=test_upf_access_ip_cidr.split("/")[0]
+        )
+
+    @patch("charms.sdcore_upf.v0.fiveg_n3.N3Provides.publish_upf_information")
+    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch("ops.model.Container.push", new=Mock)
+    @patch("ops.model.Container.exec", new=Mock)
+    @patch("ops.model.Container.pull", new=Mock)
+    @patch("ops.model.Container.exists")
+    def test_given_fiveg_n3_relation_exists_when_access_ip_config_changed_then_new_upf_ip_address_is_published(  # noqa: E501
+        self, patch_exists, patch_multus_is_ready, patched_publish_upf_information
+    ):
+        patch_exists.return_value = True
+        patch_multus_is_ready.return_value = True
+        self.harness.set_can_connect(container="bessd", val=True)
+        self.harness.set_can_connect(container="routectl", val=True)
+        self.harness.set_can_connect(container="web", val=True)
+        self.harness.set_can_connect(container="pfcp-agent", val=True)
+        self.harness.set_leader(is_leader=True)
+        n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
+        self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
+        test_upf_access_ip_cidr = "1.2.3.4/21"
+        expected_calls = [
+            call(relation_id=n3_relation_id, upf_ip_address="192.168.252.3"),
+            call(relation_id=n3_relation_id, upf_ip_address=test_upf_access_ip_cidr.split("/")[0]),
+        ]
+
+        self.harness.update_config(key_values={"access-ip": test_upf_access_ip_cidr})
+
+        patched_publish_upf_information.assert_has_calls(expected_calls)
+
+    @patch("charms.sdcore_upf.v0.fiveg_n3.N3Provides.publish_upf_information")
+    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch("ops.model.Container.push", new=Mock)
+    @patch("ops.model.Container.exec", new=Mock)
+    @patch("ops.model.Container.pull", new=Mock)
+    @patch("ops.model.Container.exists")
+    def test_given_fiveg_n3_relation_exists_when_access_ip_config_changed_to_invalid_cidr_then_new_upf_ip_address_is_not_published(  # noqa: E501
+        self, patch_exists, patch_multus_is_ready, patched_publish_upf_information
+    ):
+        patch_exists.return_value = True
+        patch_multus_is_ready.return_value = True
+        self.harness.set_can_connect(container="bessd", val=True)
+        self.harness.set_can_connect(container="routectl", val=True)
+        self.harness.set_can_connect(container="web", val=True)
+        self.harness.set_can_connect(container="pfcp-agent", val=True)
+        self.harness.set_leader(is_leader=True)
+        n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
+        self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
+        invalid_test_upf_access_ip_cidr = "1111.2.3.4/21"
+
+        self.harness.update_config(key_values={"access-ip": invalid_test_upf_access_ip_cidr})
+
+        patched_publish_upf_information.assert_called_once_with(
+            relation_id=n3_relation_id, upf_ip_address="192.168.252.3"
+        )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -532,6 +532,18 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charms.sdcore_upf.v0.fiveg_n3.N3Provides.publish_upf_information")
+    def test_given_unit_is_not_leader_when_fiveg_n3_request_then_upf_ip_address_is_not_published(
+        self, patched_publish_upf_information
+    ):
+        test_upf_access_ip_cidr = "1.2.3.4/21"
+        self.harness.update_config(key_values={"access-ip": test_upf_access_ip_cidr})
+
+        n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
+        self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
+
+        patched_publish_upf_information.assert_not_called()
+
+    @patch("charms.sdcore_upf.v0.fiveg_n3.N3Provides.publish_upf_information")
     @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
     @patch("ops.model.Container.push", new=Mock)
     @patch("ops.model.Container.exec", new=Mock)


### PR DESCRIPTION
# Description

Implements `fiveg_n3` provider side in the UPF  charm.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
