### PR TITLE
Use BESS rock for 'bessd' and 'routectl' and PFCPIFACE rock for 'pfcp-agent'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ juju deploy upf-operator --trust --channel=edge
 
 ## Image
 
-- **bessd**: omecproject/upf-epc-bess:master-5786085
-- **routectl**: omecproject/upf-epc-bess:master-5786085
+- **bessd**: ghcr.io/canonical/sdcore-upf-bess:1.3
+- **routectl**: ghcr.io/canonical/sdcore-upf-bess:1.3
 - **pfcp-agent**: omecproject/upf-epc-pfcpiface:master-5786085

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ juju deploy upf-operator --trust --channel=edge
 
 - **bessd**: ghcr.io/canonical/sdcore-upf-bess:1.3
 - **routectl**: ghcr.io/canonical/sdcore-upf-bess:1.3
-- **pfcp-agent**: omecproject/upf-epc-pfcpiface:master-5786085
+- **pfcp-agent**: ghcr.io/canonical/sdcore-upf-pfcpiface:1.3

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -37,7 +37,7 @@ resources:
   pfcp-agent-image:
     type: oci-image
     description: OCI image for 5G upf pfcp-agent
-    upstream-source: omecproject/upf-epc-pfcpiface:master-5786085
+    upstream-source: ghcr.io/canonical/sdcore-upf-pfcpiface:1.3
 
 storage:
   config:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,12 +27,12 @@ resources:
   bessd-image:
     type: oci-image
     description: OCI image for 5G upf bessd
-    upstream-source: omecproject/upf-epc-bess:master-5786085
+    upstream-source: ghcr.io/canonical/sdcore-upf-bess:1.3
 
   routectl-image:
     type: oci-image
     description: OCI image for 5G upf routectl
-    upstream-source: omecproject/upf-epc-bess:master-5786085
+    upstream-source: ghcr.io/canonical/sdcore-upf-bess:1.3
 
   pfcp-agent-image:
     type: oci-image

--- a/src/charm.py
+++ b/src/charm.py
@@ -295,7 +295,7 @@ class UPFOperatorCharm(CharmBase):
         while time.time() - initial_time <= timeout:
             try:
                 self._exec_command_in_bessd_workload(
-                    command="bessctl run /opt/bess/bessctl/conf/up4",
+                    command="/opt/bess/bessctl/bessctl run /opt/bess/bessctl/conf/up4",
                     environment=self._bessd_environment_variables,
                 )
                 return
@@ -340,7 +340,7 @@ class UPFOperatorCharm(CharmBase):
         """
         try:
             self._exec_command_in_bessd_workload(
-                command="iptables --check OUTPUT -p icmp --icmp-type port-unreachable -j DROP"
+                command="iptables-legacy --check OUTPUT -p icmp --icmp-type port-unreachable -j DROP"  # noqa: E501
             )
             return True
         except ExecError:
@@ -349,7 +349,7 @@ class UPFOperatorCharm(CharmBase):
     def _create_ip_tables_rule(self) -> None:
         """Creates iptable rule in the OUTPUT chain to block ICMP port-unreachable packets."""
         self._exec_command_in_bessd_workload(
-            command="iptables -I OUTPUT -p icmp --icmp-type port-unreachable -j DROP"
+            command="iptables-legacy -I OUTPUT -p icmp --icmp-type port-unreachable -j DROP"
         )
         logger.info("Iptables rule for ICMP created")
 
@@ -428,7 +428,7 @@ class UPFOperatorCharm(CharmBase):
                     self._bessd_service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": f"bessd -f -grpc-url=0.0.0.0:{BESSD_PORT} -m 0",  # "-m 0" means that we are not using hugepages  # noqa: E501
+                        "command": f"/bin/bessd -f -grpc-url=0.0.0.0:{BESSD_PORT} -m 0",  # "-m 0" means that we are not using hugepages  # noqa: E501
                         "environment": self._bessd_environment_variables,
                     },
                 },
@@ -479,11 +479,13 @@ class UPFOperatorCharm(CharmBase):
     def _bessd_environment_variables(self) -> dict:
         return {
             "CONF_FILE": f"{BESSD_CONTAINER_CONFIG_PATH}/{CONFIG_FILE_NAME}",
+            "PYTHONPATH": "/opt/bess",
         }
 
     @property
     def _routectl_environment_variables(self) -> dict:
         return {
+            "PYTHONPATH": "/opt/bess",
             "PYTHONUNBUFFERED": "1",
         }
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -115,8 +115,11 @@ class TestCharm(unittest.TestCase):
                 "bessd": {
                     "startup": "enabled",
                     "override": "replace",
-                    "command": "bessd -f -grpc-url=0.0.0.0:10514 -m 0",
-                    "environment": {"CONF_FILE": "/etc/bess/conf/upf.json"},
+                    "command": "/bin/bessd -f -grpc-url=0.0.0.0:10514 -m 0",
+                    "environment": {
+                        "CONF_FILE": "/etc/bess/conf/upf.json",
+                        "PYTHONPATH": "/opt/bess",
+                    },
                 }
             }
         }
@@ -176,7 +179,7 @@ class TestCharm(unittest.TestCase):
 
         patch_exec.assert_any_call(
             command=[
-                "iptables",
+                "iptables-legacy",
                 "-I",
                 "OUTPUT",
                 "-p",
@@ -238,9 +241,9 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(container_name="bessd")
 
         patch_exec.assert_any_call(
-            command=["bessctl", "run", "/opt/bess/bessctl/conf/up4"],
+            command=["/opt/bess/bessctl/bessctl", "run", "/opt/bess/bessctl/conf/up4"],
             timeout=30,
-            environment={"CONF_FILE": "/etc/bess/conf/upf.json"},
+            environment={"CONF_FILE": "/etc/bess/conf/upf.json", "PYTHONPATH": "/opt/bess"},
         )
 
     @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
@@ -324,7 +327,7 @@ class TestCharm(unittest.TestCase):
                     "startup": "enabled",
                     "override": "replace",
                     "command": "/opt/bess/bessctl/conf/route_control.py -i access core",
-                    "environment": {"PYTHONUNBUFFERED": "1"},
+                    "environment": {"PYTHONPATH": "/opt/bess", "PYTHONUNBUFFERED": "1"},
                 }
             }
         }

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, unit, static
+envlist = lint, static, unit
 
 [vars]
 src_path = {toxinidir}/src/


### PR DESCRIPTION
# Description

Use the first version of the BESS rock for both `bessd` and `routectl` containers. The rock is smaller than upstream's image.

Use the PFCPIFACE rock for the `pfcp-agent` container. The rock is a bit larger than upstream because of `pebble`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
