### PR TITLE
(Fix) Making sure routectl service always starts last

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -377,8 +377,8 @@ class UPFOperatorCharm(CharmBase):
             self._routectl_container.add_layer(
                 "routectl", self._routectl_pebble_layer, combine=True
             )
-            self._routectl_container.restart(self._routectl_service_name)
-            logger.info("Service `routectl` restarted")
+        self._routectl_container.restart(self._routectl_service_name)
+        logger.info("Service `routectl` restarted")
 
     def _configure_pfcp_agent_workload(self) -> None:
         """Configures pebble layer for `pfcp-agent` container."""


### PR DESCRIPTION
# Description

- Makes sure `routectl` service is restarted regardless of whether the pebble layer was changed
- Bumps `multus` library to the latest version

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
