### PR TITLE
Allow specifying host interface to use for multus interfaces

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,9 @@ options:
     type: string
     default: 192.168.251.0/24
     description: gNodeB subnet.
+  core-interface:
+    type: string
+    description: Interface on the host to use for the Core Network.
   core-ip:
     type: string
     default: 192.168.250.3/24
@@ -15,6 +18,9 @@ options:
     type: string
     default: 192.168.250.1
     description: Gateway IP address to the Core Network.
+  access-interface:
+    type: string
+    description: Interface on the host to use for the Access Network.
   access-ip:
     type: string
     default: 192.168.252.3/24

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ ops
 jinja2
 lightkube
 lightkube-models
-pydantic
+pydantic==2.0.2
 pytest-interface-tester
+PyYAML>=6.0.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -123,7 +123,6 @@ class UPFOperatorCharm(CharmBase):
         """Returns list of Multus NetworkAttachmentDefinitions to be created based on config."""
         access_nad_config = {
             "cniVersion": "0.3.1",
-            "type": "macvlan",
             "ipam": {
                 "type": "static",
                 "routes": [
@@ -141,10 +140,11 @@ class UPFOperatorCharm(CharmBase):
             "capabilities": {"mac": True},
         }
         if (access_interface := self._get_access_interface_config()) is not None:
-            access_nad_config.update({"master": access_interface})
+            access_nad_config.update({"type": "macvlan", "master": access_interface})
+        else:
+            access_nad_config.update({"type": "bridge", "bridge": "access-br"})
         core_nad_config = {
             "cniVersion": "0.3.1",
-            "type": "macvlan",
             "ipam": {
                 "type": "static",
                 "addresses": [
@@ -156,7 +156,9 @@ class UPFOperatorCharm(CharmBase):
             "capabilities": {"mac": True},
         }
         if (core_interface := self._get_core_interface_config()) is not None:
-            core_nad_config.update({"master": core_interface})
+            core_nad_config.update({"type": "macvlan", "master": core_interface})
+        else:
+            core_nad_config.update({"type": "bridge", "bridge": "core-br"})
         return [
             NetworkAttachmentDefinition(
                 metadata=ObjectMeta(name=ACCESS_NETWORK_ATTACHMENT_DEFINITION_NAME),

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
-juju==3.2.0.0
+juju==3.2.0.1
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -484,6 +484,8 @@ class TestCharm(unittest.TestCase):
         for nad in nads:
             config = json.loads(nad.spec["config"])
             self.assertNotIn("master", config)
+            self.assertEqual("bridge", config["type"])
+            self.assertIn(config["bridge"], ("core-br", "access-br"))
 
     def test_given_default_config_with_interfaces_when_network_attachment_definitions_from_config_is_called_then_interfaces_specified_in_nad(  # noqa: E501
         self,
@@ -504,3 +506,4 @@ class TestCharm(unittest.TestCase):
         for nad in nads:
             config = json.loads(nad.spec["config"])
             self.assertEqual(config["master"], nad.metadata.name)
+            self.assertEqual(config["type"], "macvlan")


### PR DESCRIPTION
# Description

By default, a `macvlan` interface will use the underlying host's interface with the default gateway. When following the tutorial, all interfaces share the same underlying host's interface.

However, it prevents connectivity with the outside world for real world scenario, like connecting a real `gNodeB`, or deploying the `UPF` on the edge, away from the core.

This change allows specifying what host interface to use for each multus interfaces, allowing the operator to expose the `UPF` to external networks.

When not specifying interfaces, `multus` interfaces will be created with the `bridge` plugin, separating the network traffic in different networks.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
