### PR TITLE
(Feat) Removing separate container for the routectl

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,9 +12,6 @@ containers:
       - storage: shared-app
         location: /pod-share/
 
-  routectl:
-    resource: routectl-image
-
   pfcp-agent:
     resource: pfcp-agent-image
     mounts:
@@ -27,11 +24,6 @@ resources:
   bessd-image:
     type: oci-image
     description: OCI image for 5G upf bessd
-    upstream-source: ghcr.io/canonical/sdcore-upf-bess:1.3
-
-  routectl-image:
-    type: oci-image
-    description: OCI image for 5G upf routectl
     upstream-source: ghcr.io/canonical/sdcore-upf-bess:1.3
 
   pfcp-agent-image:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -22,7 +22,6 @@ async def build_and_deploy(ops_test):
     charm = await ops_test.build_charm(".")
     resources = {
         "bessd-image": METADATA["resources"]["bessd-image"]["upstream-source"],
-        "routectl-image": METADATA["resources"]["routectl-image"]["upstream-source"],
         "pfcp-agent-image": METADATA["resources"]["pfcp-agent-image"]["upstream-source"],
     }
     await ops_test.model.deploy(


### PR DESCRIPTION
# Description

Both `bessd` and `routectl` used the same image, so there was no sense in keeping them separated.
This PR removes dedicated `routectl` container and moves its workload to the `bessd` container. The `routectl` service starts before the `bessd`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
