### PR TITLE
Removes defer calls in config changed handlers

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -217,11 +217,9 @@ class UPFOperatorCharm(CharmBase):
             return
         if not self._bessd_container.can_connect():
             self.unit.status = WaitingStatus("Waiting for bessd container to be ready")
-            event.defer()
             return
         if not self._pfcp_agent_container.can_connect():
             self.unit.status = WaitingStatus("Waiting for pfcp agent container to be ready")
-            event.defer()
             return
         self._on_bessd_pebble_ready(event)
         self._on_pfcp_agent_pebble_ready(event)

--- a/src/charm.py
+++ b/src/charm.py
@@ -228,6 +228,10 @@ class UPFOperatorCharm(CharmBase):
         """Handle Pebble ready event."""
         if not self.unit.is_leader():
             return
+        if not self._bessd_container.can_connect():
+            self.unit.status = WaitingStatus("Waiting for bessd container to be ready")
+            event.defer()
+            return
         if not self._kubernetes_multus.is_ready():
             self.unit.status = WaitingStatus("Waiting for Multus to be ready")
             event.defer()
@@ -242,6 +246,10 @@ class UPFOperatorCharm(CharmBase):
     def _on_pfcp_agent_pebble_ready(self, event: EventBase) -> None:
         """Handle pfcp agent Pebble ready event."""
         if not self.unit.is_leader():
+            return
+        if not self._pfcp_agent_container.can_connect():
+            self.unit.status = WaitingStatus("Waiting for pfcp agent container to be ready")
+            event.defer()
             return
         if not service_is_running_on_container(self._bessd_container, self._bessd_service_name):
             self.unit.status = WaitingStatus("Waiting for bessd service to run")


### PR DESCRIPTION
# Description

If the container is down there is no need to `defer` config changed event and rerun the handler, pebble_ready event will run the handler when the container is up again.
The main reason for this pr is to avoid running `up4` twice in a row quickly. 


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
