### PR TITLE
Increasing timeout for bess configuration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -290,9 +290,10 @@ class UPFOperatorCharm(CharmBase):
     def _run_bess_configuration(self) -> None:
         """Runs bessd configuration in workload."""
         initial_time = time.time()
-        timeout = 30
+        timeout = 300
         while time.time() - initial_time <= timeout:
             try:
+                logger.info("Starting configuration of the `bessd` service")
                 self._exec_command_in_bessd_workload(
                     command="/opt/bess/bessctl/bessctl run /opt/bess/bessctl/conf/up4",
                     timeout=timeout,


### PR DESCRIPTION
# Description

Increases timeout for bessd configuration.
Context:
As part of creation of the uplink and downlink pipelines, `up4.bess` also creates traffic filters. This is done by calling the `bess daemon`. On a low-spec HW, it often happens that the `bess daemon` still processes addition of one filter when another request comes in. As a result, `bess` configuration script will fail saying that the `bess daemon` is busy and the operation of adding filters is not multi-thread safe. Increasing the timeout in the charm doesn't fix the problem, but will give the charm enough time to retry running the configuration. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
