### PR TITLE
Rollback K8s Service patcher attribute

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -65,7 +65,13 @@ class UPFOperatorCharm(CharmBase):
                 }
             ],
         )
-        self._service_patcher = self._get_k8s_service_patcher()
+        self._service_patcher = KubernetesServicePatch(
+            charm=self,
+            ports=[
+                ServicePort(name="pfcp", port=8805, protocol="UDP"),
+                ServicePort(name="prometheus-exporter", port=PROMETHEUS_PORT),
+            ],
+        )
         self._kubernetes_multus = KubernetesMultusCharmLib(
             charm=self,
             container_name=self._bessd_container_name,
@@ -88,18 +94,6 @@ class UPFOperatorCharm(CharmBase):
         self.framework.observe(
             self.fiveg_n3_provider.on.fiveg_n3_request, self._on_fiveg_n3_request
         )
-
-    def _get_k8s_service_patcher(self) -> KubernetesServicePatch:
-        try:
-            return KubernetesServicePatch(
-                charm=self,
-                ports=[
-                    ServicePort(name="pfcp", port=8805, protocol="UDP"),
-                    ServicePort(name="prometheus-exporter", port=PROMETHEUS_PORT),
-                ],
-            )
-        except FileNotFoundError as e:
-            logger.warning("Can not create Kubernetes service patcher: %s", str(e))
 
     def _on_fiveg_n3_request(self, event: EventBase) -> None:
         """Handles 5G N3 requests events.


### PR DESCRIPTION
# Description

This change rollbacks the k8s_service_patcher object creation which is done by https://github.com/canonical/sdcore-upf-operator/pull/26.
We do not expect to get FileNotFoundError during KubernetesServicePatch object creation and we do not need to suppress it. In the unit tests kubernetes namespace file lookup is already mocked. 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
