### PR TITLE
Correcting charm name to be deployed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ juju add-model user-plane
 Deploy the UPF:
 
 ```bash
-juju deploy upf-operator --trust --channel=edge
+juju deploy sdcore-upf --trust --channel=edge
 ```
 
 ## Image


### PR DESCRIPTION
# Description

This PR corrects the charm name to be deployed in README.md which is indicating wrong charm.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
