### PR TITLE
(Feat) Adding CPU compatibility check

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Charmed Operator for SD-Core's User Plane Function (UPF). For more information, 
 
 ## Pre-requisites
 
+A Kubernetes host with a CPU supporting AVX2 and RDRAND instructions (Intel Haswell, AMD Excavator or equivalent)
+
 A Kubernetes cluster with the Multus addon enabled.
 
 ## Usage

--- a/src/charm.py
+++ b/src/charm.py
@@ -48,6 +48,12 @@ PROMETHEUS_PORT = 8080
 REQUIRED_CPU_EXTENSIONS = ["avx2", "rdrand"]
 
 
+class IncompatibleCPUError(Exception):
+    """Custom error to be raised when CPU doesn't support required instructions."""
+
+    pass
+
+
 class UPFOperatorCharm(CharmBase):
     """Main class to describe juju event handling for the 5G UPF operator."""
 
@@ -108,14 +114,11 @@ class UPFOperatorCharm(CharmBase):
             event: Juju event
         """
         if not self._is_cpu_compatible():
-            self.unit.status = BlockedStatus("CPU is not compatible")
-            logger.error(
-                "CPU is not compatible!\n"
+            raise IncompatibleCPUError(
+                "\nCPU is not compatible!\n"
                 "Please use a CPU that has the following capabilities: "
                 f"{', '.join(REQUIRED_CPU_EXTENSIONS)}"
             )
-            event.defer()
-            return
 
     def _on_fiveg_n3_request(self, event: EventBase) -> None:
         """Handles 5G N3 requests events.

--- a/src/charm.py
+++ b/src/charm.py
@@ -90,7 +90,7 @@ class UPFOperatorCharm(CharmBase):
             ],
             network_attachment_definitions_func=self._network_attachment_definitions_from_config,
         )
-        self.framework.observe(self.on.start, self._on_start)
+        self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.bessd_pebble_ready, self._on_bessd_pebble_ready)
         self.framework.observe(self.on.pfcp_agent_pebble_ready, self._on_pfcp_agent_pebble_ready)
@@ -98,8 +98,8 @@ class UPFOperatorCharm(CharmBase):
             self.fiveg_n3_provider.on.fiveg_n3_request, self._on_fiveg_n3_request
         )
 
-    def _on_start(self, event: EventBase) -> None:
-        """Handler for Juju start event.
+    def _on_install(self, event: EventBase) -> None:
+        """Handler for Juju install event.
 
         This handler enforces usage of a CPU which supports instructions required to run this
         charm. If the CPU doesn't meet the requirements, charm goes to Blocked state.
@@ -600,8 +600,8 @@ class UPFOperatorCharm(CharmBase):
             bool: Whether the CPU meets requirements to run this charm
         """
         return all(
-            required_extention in self._get_cpu_extensions()
-            for required_extention in REQUIRED_CPU_EXTENSIONS
+            required_extension in self._get_cpu_extensions()
+            for required_extension in REQUIRED_CPU_EXTENSIONS
         )
 
     @staticmethod

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -520,7 +520,7 @@ class TestCharm(unittest.TestCase):
     ):
         patched_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
 
-        self.harness.charm.on.start.emit()
+        self.harness.charm.on.install.emit()
 
         self.assertEqual(
             self.harness.model.unit.status,
@@ -534,7 +534,7 @@ class TestCharm(unittest.TestCase):
         patched_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
 
         with self.assertLogs() as logs:
-            self.harness.charm.on.start.emit()
+            self.harness.charm.on.install.emit()
 
         self.assertEqual(
             logs.records[0].message,
@@ -548,6 +548,6 @@ class TestCharm(unittest.TestCase):
     ):
         patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand"
 
-        self.harness.charm.on.start.emit()
+        self.harness.charm.on.install.emit()
 
         self.assertEqual(self.harness.model.unit.status, MaintenanceStatus())

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,7 @@ from io import StringIO
 from unittest.mock import MagicMock, Mock, call, patch
 
 from ops import testing
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import ExecError
 
 from charm import UPFOperatorCharm
@@ -513,3 +513,41 @@ class TestCharm(unittest.TestCase):
             config = json.loads(nad.spec["config"])
             self.assertEqual(config["master"], nad.metadata.name)
             self.assertEqual(config["type"], "macvlan")
+
+    @patch("charm.check_output")
+    def test_given_cpu_not_supporting_required_instructions_when_start_then_charm_goes_to_blocked_status(  # noqa: E501
+        self, patched_check_output
+    ):
+        patched_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
+
+        self.harness.charm.on.start.emit()
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("CPU is not compatible"),
+        )
+
+    @patch("charm.check_output")
+    def test_given_cpu_not_supporting_required_instructions_when_start_then_error_message_is_logged(  # noqa: E501
+        self, patched_check_output
+    ):
+        patched_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
+
+        with self.assertLogs() as logs:
+            self.harness.charm.on.start.emit()
+
+        self.assertEqual(
+            logs.records[0].message,
+            "CPU is not compatible!\n"
+            "Please use a CPU that has the following capabilities: avx2, rdrand",
+        )
+
+    @patch("charm.check_output")
+    def test_given_cpu_supporting_required_instructions_when_start_then_charm_goes_to_maintenance_status(  # noqa: E501
+        self, patched_check_output
+    ):
+        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand"
+
+        self.harness.charm.on.start.emit()
+
+        self.assertEqual(self.harness.model.unit.status, MaintenanceStatus())


### PR DESCRIPTION
# Description

This PR implements CPU compatibility check. 
Check fails if the CPU doesn't support required extensions (currently it's `avx2` and `rdrand`). Failed check puts charm in Blocked status.
Check leverages the output of `lscpu` command. Alternatively we could use [py-cpuinfo](https://pypi.org/project/py-cpuinfo/), but it seems to be rarely maintained.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
