### PR TITLE
(Feat) Adding fiveg_n4 library

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,7 @@ jobs:
       charm-file-name: "sdcore-upf_ubuntu-22.04-amd64.charm"
     secrets: inherit
 
-  lib-needs-publishing:
+  fiveg-n3-lib-needs-publishing:
     runs-on: ubuntu-22.04
     outputs:
       needs-publishing: ${{ steps.changes.outputs.fiveg_n3 }}
@@ -55,13 +55,37 @@ jobs:
             fiveg_n3:
               - 'lib/charms/sdcore_upf/v0/fiveg_n3.py'
 
-  publish-lib:
+  publish-fiveg-n3-lib:
     name: Publish Lib
     needs:
       - publish-charm
-      - lib-needs-publishing
+      - fiveg-n3-lib-needs-publishing
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@main
     with:
       lib-name: "charms.sdcore_upf.v0.fiveg_n3"
+    secrets: inherit
+
+  fiveg-n4-lib-needs-publishing:
+    runs-on: ubuntu-22.04
+    outputs:
+      needs-publishing: ${{ steps.changes.outputs.fiveg_n4 }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            fiveg_n4:
+              - 'lib/charms/sdcore_upf/v0/fiveg_n4.py'
+
+  publish-fiveg-n4-lib:
+    name: Publish Lib
+    needs:
+      - publish-charm
+      - fiveg-n4-lib-needs-publishing
+    if: ${{ github.ref_name == 'main' }}
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@main
+    with:
+      lib-name: "charms.sdcore_upf.v0.fiveg_n4"
     secrets: inherit

--- a/lib/charms/sdcore_upf/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf/v0/fiveg_n4.py
@@ -203,7 +203,7 @@ class N4Provides(Object):
     def publish_upf_n4_information(
         self, relation_id: int, upf_hostname: str, upf_n4_port: int
     ) -> None:
-        """Sets UPF's IP address in the relation data.
+        """Sets UPF's hostname and port in the relation data.
 
         Args:
             relation_id (str): Relation ID

--- a/lib/charms/sdcore_upf/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf/v0/fiveg_n4.py
@@ -136,7 +136,7 @@ class ProviderAppData(BaseModel):
 
 
 class ProviderSchema(DataBagSchema):
-    """Provider schema for fiveg_n3."""
+    """Provider schema for fiveg_n4."""
 
     app: ProviderAppData
 

--- a/lib/charms/sdcore_upf/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf/v0/fiveg_n4.py
@@ -122,7 +122,7 @@ Examples:
 """
 
 
-class ProviderAppData(BaseModel):
+class FivegN4ProviderAppData(BaseModel):
     """Provider app data for fiveg_n4."""
 
     upf_hostname: str = Field(
@@ -138,7 +138,7 @@ class ProviderAppData(BaseModel):
 class ProviderSchema(DataBagSchema):
     """Provider schema for fiveg_n4."""
 
-    app: ProviderAppData
+    app: FivegN4ProviderAppData
 
 
 def data_matches_provider_schema(data: dict) -> bool:

--- a/lib/charms/sdcore_upf/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf/v0/fiveg_n4.py
@@ -235,7 +235,7 @@ class N4AvailableEvent(EventBase):
     """Dataclass for the `fiveg_n4` available event."""
 
     def __init__(self, handle, upf_hostname: str, upf_port: int):
-        """Sets certificate."""
+        """Sets UPF's hostname and port."""
         super().__init__(handle)
         self.upf_hostname = upf_hostname
         self.upf_port = upf_port

--- a/lib/charms/sdcore_upf/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf/v0/fiveg_n4.py
@@ -1,0 +1,290 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the `fiveg_n4` relation.
+
+This library contains the Requires and Provides classes for handling the `fiveg_n4`
+interface.
+
+The purpose of this library is to integrate a charm claiming to be able to provide
+information required to establish communication over the N4 interface with a charm
+claiming to be able to consume this information.
+
+To get started using the library, you need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.sdcore_upf.v0.fiveg_n4
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- pydantic
+- pytest-interface-tester
+
+Charms providing the `fiveg_n4` relation should use `N4Provides`.
+Typical usage of this class would look something like:
+
+    ```python
+    ...
+    from charms.sdcore_upf.v0.fiveg_n4 import N4Provides
+    ...
+
+    class SomeProviderCharm(CharmBase):
+
+        def __init__(self, *args):
+            ...
+            self.fiveg_n4 = N4Provides(charm=self, relation_name="fiveg_n4")
+            ...
+            self.framework.observe(self.fiveg_n4.on.fiveg_n4_request, self._on_fiveg_n4_request)
+
+        def _on_fiveg_n4_request(self, event):
+            ...
+            self.fiveg_n4.publish_upf_n4_information(
+                relation_id=event.relation_id,
+                upf_hostname=hostname,
+                upf_port=n4_port,
+            )
+    ```
+
+    And a corresponding section in charm's `metadata.yaml`:
+    ```
+    provides:
+        fiveg_n4:  # Relation name
+            interface: fiveg_n4  # Relation interface
+    ```
+
+Charms that require the `fiveg_n4` relation should use `N4Requires`.
+Typical usage of this class would look something like:
+
+    ```python
+    ...
+    from charms.sdcore_upf.v0.fiveg_n4 import N4Requires
+    ...
+
+    class SomeRequirerCharm(CharmBase):
+
+        def __init__(self, *args):
+            ...
+            self.fiveg_n4 = N4Requires(charm=self, relation_name="fiveg_n4")
+            ...
+            self.framework.observe(self.upf.on.fiveg_n4_available, self._on_fiveg_n4_available)
+
+        def _on_fiveg_n4_available(self, event):
+            upf_hostname = event.upf_hostname,
+            upf_port = event.upf_port,
+            # Do something with the UPF's hostname and port
+    ```
+
+    And a corresponding section in charm's `metadata.yaml`:
+    ```
+    requires:
+        fiveg_n4:  # Relation name
+            interface: fiveg_n4  # Relation interface
+    ```
+"""
+
+import logging
+
+from interface_tester.schema_base import DataBagSchema  # type: ignore[import]
+from ops.charm import CharmBase, CharmEvents, RelationChangedEvent, RelationJoinedEvent
+from ops.framework import EventBase, EventSource, Object
+from pydantic import BaseModel, Field, ValidationError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "bc6261cf77104d4fb3edfd6d4ea63149"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+PYDEPS = ["pydantic", "pytest-interface-tester"]
+
+
+logger = logging.getLogger(__name__)
+
+"""Schemas definition for the provider and requirer sides of the `fiveg_n3` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "upf_hostname": "upf.uplane-cloud.canonical.com",
+            "upf_port": 8805
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+
+class ProviderAppData(BaseModel):
+    """Provider app data for fiveg_n4."""
+
+    upf_hostname: str = Field(
+        description="Name of the host exposing the UPF's N4 interface.",
+        examples=["upf.uplane-cloud.canonical.com"],
+    )
+    upf_port: int = Field(
+        description="Port on which UPF's N4 interface is exposed.",
+        examples=[8805],
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for fiveg_n3."""
+
+    app: ProviderAppData
+
+
+def data_matches_provider_schema(data: dict) -> bool:
+    """Returns whether data matches provider schema.
+
+    Args:
+        data (dict): Data to be validated.
+
+    Returns:
+        bool: True if data matches provider schema, False otherwise.
+    """
+    try:
+        ProviderSchema(app=data)
+        return True
+    except ValidationError as e:
+        logger.error("Invalid data: %s", e)
+        return False
+
+
+class FiveGN4RequestEvent(EventBase):
+    """Dataclass for the `fiveg_n4` request event."""
+
+    def __init__(self, handle, relation_id: int):
+        """Sets relation id."""
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Returns event data."""
+        return {
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot):
+        """Restores event data."""
+        self.relation_id = snapshot["relation_id"]
+
+
+class N4ProviderCharmEvents(CharmEvents):
+    """Custom events for the N4Provider."""
+
+    fiveg_n4_request = EventSource(FiveGN4RequestEvent)
+
+
+class N4Provides(Object):
+    """Class to be instantiated by provider of the `fiveg_n4`."""
+
+    on = N4ProviderCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Observes relation joined event.
+
+        Args:
+            charm: Juju charm
+            relation_name (str): Relation name
+        """
+        self.relation_name = relation_name
+        self.charm = charm
+        super().__init__(charm, relation_name)
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_joined)
+
+    def publish_upf_n4_information(
+        self, relation_id: int, upf_hostname: str, upf_n4_port: int
+    ) -> None:
+        """Sets UPF's IP address in the relation data.
+
+        Args:
+            relation_id (str): Relation ID
+            upf_hostname (str): UPF's hostname
+            upf_n4_port (int): Port on which UPF accepts N4 communication
+        """
+        if not data_matches_provider_schema(
+            data={"upf_hostname": upf_hostname, "upf_port": upf_n4_port}
+        ):
+            raise ValueError(f"Invalid UPF N4 data: {upf_hostname}, {upf_n4_port}")
+        relation = self.model.get_relation(
+            relation_name=self.relation_name, relation_id=relation_id
+        )
+        if not relation:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+        relation.data[self.charm.app]["upf_hostname"] = upf_hostname
+        relation.data[self.charm.app]["upf_port"] = str(upf_n4_port)
+
+    def _on_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Triggered whenever a requirer charm joins the relation.
+
+        Args:
+            event (RelationJoinedEvent): Juju event
+        """
+        self.on.fiveg_n4_request.emit(relation_id=event.relation.id)
+
+
+class N4AvailableEvent(EventBase):
+    """Dataclass for the `fiveg_n4` available event."""
+
+    def __init__(self, handle, upf_hostname: str, upf_port: int):
+        """Sets certificate."""
+        super().__init__(handle)
+        self.upf_hostname = upf_hostname
+        self.upf_port = upf_port
+
+    def snapshot(self) -> dict:
+        """Returns event data."""
+        return {
+            "upf_hostname": self.upf_hostname,
+            "upf_port": self.upf_port,
+        }
+
+    def restore(self, snapshot):
+        """Restores event data."""
+        self.upf_hostname = snapshot["upf_hostname"]
+        self.upf_port = snapshot["upf_port"]
+
+
+class N4RequirerCharmEvents(CharmEvents):
+    """Custom events for the N4Requirer."""
+
+    fiveg_n4_available = EventSource(N4AvailableEvent)
+
+
+class N4Requires(Object):
+    """Class to be instantiated by requirer of the `fiveg_n4`."""
+
+    on = N4RequirerCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Observes relation joined and relation changed events.
+
+        Args:
+            charm: Juju charm
+            relation_name (str): Relation name
+        """
+        self.relation_name = relation_name
+        self.charm = charm
+        super().__init__(charm, relation_name)
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_changed)
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Triggered everytime there's a change in relation data.
+
+        Args:
+            event (RelationChangedEvent): Juju event
+        """
+        relation_data = event.relation.data
+        upf_hostname = relation_data[event.unit].get("upf_hostname")  # type: ignore[index]
+        upf_port = relation_data[event.unit].get("upf_port")  # type: ignore[index]
+        if upf_hostname and upf_port:
+            self.on.fiveg_n4_available.emit(upf_hostname=upf_hostname, upf_port=upf_port)

--- a/lib/charms/sdcore_upf/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf/v0/fiveg_n4.py
@@ -105,7 +105,7 @@ PYDEPS = ["pydantic", "pytest-interface-tester"]
 
 logger = logging.getLogger(__name__)
 
-"""Schemas definition for the provider and requirer sides of the `fiveg_n3` interface.
+"""Schemas definition for the provider and requirer sides of the `fiveg_n4` interface.
 It exposes two interfaces.schema_base.DataBagSchema subclasses called:
 - ProviderSchema
 - RequirerSchema

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_provider_charm/metadata.yaml
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_provider_charm/metadata.yaml
@@ -13,6 +13,9 @@ resources:
     type: oci-image
     description: whatever image
 
-requires:
+provides:
   fiveg_n3:
     interface: fiveg_n3
+
+  fiveg_n4:
+    interface: fiveg_n4

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_provider_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_provider_charm/src/charm.py
@@ -4,6 +4,7 @@
 import logging
 
 from charms.sdcore_upf.v0.fiveg_n3 import N3Provides
+from charms.sdcore_upf.v0.fiveg_n4 import N4Provides
 from ops.charm import CharmBase
 from ops.main import main
 
@@ -12,20 +13,33 @@ logger = logging.getLogger(__name__)
 
 class WhateverCharm(CharmBase):
     TEST_UPF_IP_ADDRESS = ""
+    TEST_UPF_HOSTNAME = ""
+    TEST_UPF_PORT = 0
 
     def __init__(self, *args):
         """Creates a new instance of this object for each event."""
         super().__init__(*args)
         self.fiveg_n3_provider = N3Provides(self, "fiveg_n3")
+        self.fiveg_n4_provider = N4Provides(self, "fiveg_n4")
 
         self.framework.observe(
             self.fiveg_n3_provider.on.fiveg_n3_request, self._on_fiveg_n3_request
+        )
+        self.framework.observe(
+            self.fiveg_n4_provider.on.fiveg_n4_request, self._on_fiveg_n4_request
         )
 
     def _on_fiveg_n3_request(self, event):
         self.fiveg_n3_provider.publish_upf_information(
             relation_id=event.relation_id,
             upf_ip_address=self.TEST_UPF_IP_ADDRESS,
+        )
+
+    def _on_fiveg_n4_request(self, event):
+        self.fiveg_n4_provider.publish_upf_n4_information(
+            relation_id=event.relation_id,
+            upf_hostname=self.TEST_UPF_HOSTNAME,
+            upf_n4_port=self.TEST_UPF_PORT,
         )
 
 

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_requirer_charm/metadata.yaml
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_requirer_charm/metadata.yaml
@@ -13,6 +13,9 @@ resources:
     type: oci-image
     description: whatever image
 
-provides:
+requires:
   fiveg_n3:
     interface: fiveg_n3
+
+  fiveg_n4:
+    interface: fiveg_n4

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_requirer_charm/src/charm.py
@@ -4,6 +4,7 @@
 import logging
 
 from charms.sdcore_upf.v0.fiveg_n3 import N3Requires
+from charms.sdcore_upf.v0.fiveg_n4 import N4Requires
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus
@@ -16,11 +17,13 @@ class WhateverCharm(CharmBase):
         """Creates a new instance of this object for each event."""
         super().__init__(*args)
         self.fiveg_n3 = N3Requires(self, "fiveg_n3")
+        self.fiveg_n4 = N4Requires(self, "fiveg_n4")
 
-        self.framework.observe(self.fiveg_n3.on.fiveg_n3_available, self._on_fiveg_n3_available)
+        self.framework.observe(self.fiveg_n3.on.fiveg_n3_available, self._on_relation_available)
+        self.framework.observe(self.fiveg_n4.on.fiveg_n4_available, self._on_relation_available)
 
-    def _on_fiveg_n3_available(self, event):
-        self.model.unit.status = ActiveStatus(event.upf_ip_address)
+    def _on_relation_available(self, event):
+        self.model.unit.status = ActiveStatus()
 
 
 if __name__ == "__main__":

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_provider.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_provider.py
@@ -5,7 +5,9 @@ import unittest
 from unittest.mock import PropertyMock, patch
 
 from ops import testing
-from test_charms.test_fiveg_n3_provider.src.charm import WhateverCharm  # type: ignore[import]
+from test_charms.test_provider_charm.src.charm import WhateverCharm  # type: ignore[import]
+
+TEST_CHARM_PATH = "test_charms.test_provider_charm.src.charm.WhateverCharm"
 
 
 class TestN3Provides(unittest.TestCase):
@@ -15,10 +17,7 @@ class TestN3Provides(unittest.TestCase):
         self.harness.begin()
         self.relation_name = "fiveg_n3"
 
-    @patch(
-        "test_charms.test_fiveg_n3_provider.src.charm.WhateverCharm.TEST_UPF_IP_ADDRESS",
-        new_callable=PropertyMock,
-    )
+    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_IP_ADDRESS", new_callable=PropertyMock)
     def test_given_fiveg_n3_relation_when_relation_created_then_upf_ip_address_is_published_in_the_relation_data(  # noqa: E501
         self, patched_test_upf_ip
     ):
@@ -35,10 +34,7 @@ class TestN3Provides(unittest.TestCase):
         )
         self.assertEqual(test_upf_ip, relation_data["upf_ip_address"])
 
-    @patch(
-        "test_charms.test_fiveg_n3_provider.src.charm.WhateverCharm.TEST_UPF_IP_ADDRESS",
-        new_callable=PropertyMock,
-    )
+    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_IP_ADDRESS", new_callable=PropertyMock)
     def test_given_invalid_upf_ip_address_when_relation_created_then_value_error_is_raised(
         self, patched_test_upf_ip
     ):

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_provider.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_provider.py
@@ -1,0 +1,73 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import PropertyMock, patch
+
+from ops import testing
+from test_charms.test_provider_charm.src.charm import WhateverCharm  # type: ignore[import]
+
+TEST_CHARM_PATH = "test_charms.test_provider_charm.src.charm.WhateverCharm"
+
+
+class TestN4Provides(unittest.TestCase):
+    def setUp(self) -> None:
+        self.harness = testing.Harness(WhateverCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+        self.relation_name = "fiveg_n4"
+
+    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_HOSTNAME", new_callable=PropertyMock)
+    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_PORT", new_callable=PropertyMock)
+    def test_given_fiveg_n4_relation_when_relation_created_then_upf_hostname_and_upf_port_is_published_in_the_relation_data(  # noqa: E501
+        self, patched_test_upf_port, patched_test_upf_hostname
+    ):
+        self.harness.set_leader(is_leader=True)
+        test_upf_hostname = "upf.edge-cloud.test.com"
+        test_upf_port = 1234
+        patched_test_upf_hostname.return_value = test_upf_hostname
+        patched_test_upf_port.return_value = test_upf_port
+        relation_id = self.harness.add_relation(
+            relation_name=self.relation_name, remote_app="whatever-app"
+        )
+        self.harness.add_relation_unit(relation_id, "whatever-app/0")
+
+        relation_data = self.harness.get_relation_data(
+            relation_id=relation_id, app_or_unit=self.harness.charm.app
+        )
+        self.assertEqual(test_upf_hostname, relation_data["upf_hostname"])
+        self.assertEqual(str(test_upf_port), relation_data["upf_port"])
+
+    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_HOSTNAME", new_callable=PropertyMock)
+    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_PORT", new_callable=PropertyMock)
+    def test_given_invalid_upf_hostname_when_relation_created_then_value_error_is_raised(
+        self, patched_test_upf_port, patched_test_upf_hostname
+    ):
+        self.harness.set_leader(is_leader=True)
+        test_invalid_upf_hostname = 34566
+        test_upf_port = 1234
+        patched_test_upf_hostname.return_value = test_invalid_upf_hostname
+        patched_test_upf_port.return_value = test_upf_port
+
+        with self.assertRaises(ValueError):
+            relation_id = self.harness.add_relation(
+                relation_name=self.relation_name, remote_app="whatever-app"
+            )
+            self.harness.add_relation_unit(relation_id, "whatever-app/0")
+
+    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_HOSTNAME", new_callable=PropertyMock)
+    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_PORT", new_callable=PropertyMock)
+    def test_given_invalid_upf_port_when_relation_created_then_value_error_is_raised(
+        self, patched_test_upf_port, patched_test_upf_hostname
+    ):
+        self.harness.set_leader(is_leader=True)
+        test_upf_hostname = "upf.edge-cloud.test.com"
+        test_invalid_upf_port = "not_an_int"
+        patched_test_upf_hostname.return_value = test_upf_hostname
+        patched_test_upf_port.return_value = test_invalid_upf_port
+
+        with self.assertRaises(ValueError):
+            relation_id = self.harness.add_relation(
+                relation_name=self.relation_name, remote_app="whatever-app"
+            )
+            self.harness.add_relation_unit(relation_id, "whatever-app/0")

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_provider.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_provider.py
@@ -44,7 +44,7 @@ class TestN4Provides(unittest.TestCase):
         self, patched_test_upf_port, patched_test_upf_hostname
     ):
         self.harness.set_leader(is_leader=True)
-        test_invalid_upf_hostname = 34566
+        test_invalid_upf_hostname = None
         test_upf_port = 1234
         patched_test_upf_hostname.return_value = test_invalid_upf_hostname
         patched_test_upf_port.return_value = test_upf_port

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
@@ -13,13 +13,14 @@ class TestN3Requires(unittest.TestCase):
         self.harness = testing.Harness(WhateverCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
-        self.relation_name = "fiveg_n3"
+        self.relation_name = "fiveg_n4"
 
-    @patch("charms.sdcore_upf.v0.fiveg_n3.N3RequirerCharmEvents.fiveg_n3_available")
-    def test_given_relation_with_n3_profider_when_fiveg_n3_available_event_then_n3_information_is_provided(  # noqa: E501
-        self, patched_fiveg_n3_available_event
+    @patch("charms.sdcore_upf.v0.fiveg_n4.N4RequirerCharmEvents.fiveg_n4_available")
+    def test_given_relation_with_n4_profider_when_fiveg_n4_available_event_then_n4_information_is_provided(  # noqa: E501
+        self, patched_fiveg_n4_available_event
     ):
-        test_upf_ip = "1.2.3.4"
+        test_upf_hostname = "upf.edge-cloud.test.com"
+        test_upf_port = 1234
         relation_id = self.harness.add_relation(
             relation_name=self.relation_name, remote_app="whatever-app"
         )
@@ -28,10 +29,10 @@ class TestN3Requires(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=relation_id,
             app_or_unit="whatever-app/0",
-            key_values={"upf_ip_address": test_upf_ip},
+            key_values={"upf_hostname": test_upf_hostname, "upf_port": str(test_upf_port)},
         )
 
         calls = [
-            call.emit(upf_ip_address=test_upf_ip),
+            call.emit(upf_hostname=test_upf_hostname, upf_port=str(test_upf_port)),
         ]
-        patched_fiveg_n3_available_event.assert_has_calls(calls)
+        patched_fiveg_n4_available_event.assert_has_calls(calls)

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
@@ -16,7 +16,7 @@ class TestN4Requires(unittest.TestCase):
         self.relation_name = "fiveg_n4"
 
     @patch("charms.sdcore_upf.v0.fiveg_n4.N4RequirerCharmEvents.fiveg_n4_available")
-    def test_given_relation_with_n4_profider_when_fiveg_n4_available_event_then_n4_information_is_provided(  # noqa: E501
+    def test_given_relation_with_n4_provider_when_fiveg_n4_available_event_then_n4_information_is_provided(  # noqa: E501
         self, patched_fiveg_n4_available_event
     ):
         test_upf_hostname = "upf.edge-cloud.test.com"

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
@@ -8,7 +8,7 @@ from ops import testing
 from test_charms.test_requirer_charm.src.charm import WhateverCharm  # type: ignore[import]
 
 
-class TestN3Requires(unittest.TestCase):
+class TestN4Requires(unittest.TestCase):
     def setUp(self) -> None:
         self.harness = testing.Harness(WhateverCharm)
         self.addCleanup(self.harness.cleanup)


### PR DESCRIPTION
# Description

This PR adds a new `fiveg_n4`. 
The `N4` interface is typically used as a bridge between the User Plane and Control Plane. In Charmed 5G it will be primarily used to provide NMS with UPF information required to create a network slice.

**Reference:**
https://docs.google.com/document/d/1s3U82GTUZFJ9mEhiHig0oAl44F0fq3eQT2PNv1uV75g/edit

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
