### PR TITLE
(Fix) Fixing relation data

### DIFF
--- a/lib/charms/sdcore_upf/v0/fiveg_n3.py
+++ b/lib/charms/sdcore_upf/v0/fiveg_n3.py
@@ -93,7 +93,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 
@@ -260,6 +260,6 @@ class N3Requires(Object):
             event (RelationChangedEvent): Juju event
         """
         relation_data = event.relation.data
-        upf_ip_address = relation_data[event.unit].get("upf_ip_address")  # type: ignore[index]
+        upf_ip_address = relation_data[event.app].get("upf_ip_address")  # type: ignore[index]
         if upf_ip_address:
             self.on.fiveg_n3_available.emit(upf_ip_address=upf_ip_address)

--- a/lib/charms/sdcore_upf/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf/v0/fiveg_n4.py
@@ -98,7 +98,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 
@@ -284,7 +284,7 @@ class N4Requires(Object):
             event (RelationChangedEvent): Juju event
         """
         relation_data = event.relation.data
-        upf_hostname = relation_data[event.unit].get("upf_hostname")  # type: ignore[index]
-        upf_port = relation_data[event.unit].get("upf_port")  # type: ignore[index]
+        upf_hostname = relation_data[event.app].get("upf_hostname")  # type: ignore[index]
+        upf_port = relation_data[event.app].get("upf_port")  # type: ignore[index]
         if upf_hostname and upf_port:
             self.on.fiveg_n4_available.emit(upf_hostname=upf_hostname, upf_port=upf_port)

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_requirer.py
@@ -16,7 +16,7 @@ class TestN3Requires(unittest.TestCase):
         self.relation_name = "fiveg_n3"
 
     @patch("charms.sdcore_upf.v0.fiveg_n3.N3RequirerCharmEvents.fiveg_n3_available")
-    def test_given_relation_with_n3_profider_when_fiveg_n3_available_event_then_n3_information_is_provided(  # noqa: E501
+    def test_given_relation_with_n3_provider_when_fiveg_n3_available_event_then_n3_information_is_provided(  # noqa: E501
         self, patched_fiveg_n3_available_event
     ):
         test_upf_ip = "1.2.3.4"

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_requirer.py
@@ -27,7 +27,7 @@ class TestN3Requires(unittest.TestCase):
 
         self.harness.update_relation_data(
             relation_id=relation_id,
-            app_or_unit="whatever-app/0",
+            app_or_unit="whatever-app",
             key_values={"upf_ip_address": test_upf_ip},
         )
 

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
@@ -28,7 +28,7 @@ class TestN4Requires(unittest.TestCase):
 
         self.harness.update_relation_data(
             relation_id=relation_id,
-            app_or_unit="whatever-app/0",
+            app_or_unit="whatever-app",
             key_values={"upf_hostname": test_upf_hostname, "upf_port": str(test_upf_port)},
         )
 


### PR DESCRIPTION
# Description

Fixes a bug in `fiveg_n3` and `fiveg_n4` libs. 
Bug was caused by the fact that the provider side would set the app relation data, but requirer would pull the unit relation data.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
