### PR TITLE
Remove internal PFCP port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -83,7 +83,6 @@ class UPFOperatorCharm(CharmBase):
         self._service_patcher = KubernetesServicePatch(
             charm=self,
             ports=[
-                ServicePort(name="pfcp", port=PFCP_PORT, protocol="UDP"),
                 ServicePort(name="prometheus-exporter", port=PROMETHEUS_PORT),
             ],
         )


### PR DESCRIPTION
# Description

Now that an externally accessible PFCP port is exposed and should be used instead, remove the legacy internal PFCP service port.

## Related

- #36 
- https://github.com/canonical/charmed-5g/pull/126

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
