### PR TITLE
Support custom MTU sizes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,11 @@ options:
     type: string
     default: 192.168.250.1
     description: Gateway IP address to the Core Network.
+  core-interface-mtu-size:
+    type: int
+    description: |
+      MTU for the core interface (1200 <= MTU <= 65535) in bytes.
+      If not specified, Multus will use its default value (typically 1500).
   access-interface:
     type: string
     description: Interface on the host to use for the Access Network.
@@ -29,6 +34,11 @@ options:
     type: string
     default: 192.168.252.1
     description: Gateway IP address to the Access Network.
+  access-interface-mtu-size:
+    type: int
+    description: |
+      MTU for the access interface (1200 <= MTU <= 65535) in bytes.
+      If not specified, Multus will use its default value (typically 1500).
   external-upf-hostname:
     type: string
     description: |-


### PR DESCRIPTION
# Description

Adding optional configuration to set custom MTU sizes for UPF access and core interfaces. 
This branch is a replication of https://github.com/canonical/sdcore-upf-operator/pull/31 as that is having problem with the commit gpg verification.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
