### PR TITLE
fix: Remove defers in config_changed

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -104,7 +104,26 @@ class TestCharm(unittest.TestCase):
 
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     @patch("ops.model.Container.exec", new=MagicMock)
-    def test_given_bessd_config_file_matches_when_bessd_pebble_ready_then_config_file_is_not_rewritten(  # noqa: E501
+    def test_given_bessd_config_file_not_yet_written_when_config_storage_attached_then_config_file_is_written(  # noqa: E501
+        self,
+        patch_is_ready,
+    ):
+        self.harness.set_leader(is_leader=True)
+
+        self.harness.set_can_connect("bessd", True)
+        (self.root / "etc/bess/conf").rmdir()
+        self.harness.add_storage(storage_name="config", count=1)
+        self.harness.attach_storage(storage_id="config/0")
+
+        expected_config_file_content = read_file("tests/unit/expected_upf.json")
+
+        self.assertEqual(
+            (self.root / "etc/bess/conf/upf.json").read_text(), expected_config_file_content
+        )
+
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
+    @patch("ops.model.Container.exec", new=MagicMock)
+    def test_given_bessd_config_file_matches_when_bessd_pebble_ready_then_config_file_is_not_changed(  # noqa: E501
         self,
         patch_is_ready,
     ):


### PR DESCRIPTION
# Description

[fix: Remove defers in config_changed](https://github.com/canonical/sdcore-upf-operator/commit/3bc00ada30509937bc414de6675f3ddae9ff0842)

Issue https://github.com/canonical/sdcore-upf-operator/issues/47 describes a problem where Multus tries to restart the pod
after applying NetworkAttachmentDefinitions, but the unit is stuck
for about 15 minutes in a failure loop.

The logs show that `config_changed` is reemited, causing the custom
`nad_config_changed` event to be emited, calling the Multus library.

At that point, Multus is unable to properly read the
NetworkAttachmentDefinitions and fails with an uncaught exception,
crashing the charm. The unit is then stuck in a loop until a timeout
occurs on the Juju controller side.

This change removes all defers that could happen in the `config_changed`
hook. Most defers were not necessary, as `pebble_ready` events would
cover them.

The only defer that was previously critical was in the case of missing
storage. The defer was replaced by listening to the
`config_storage_attached` event.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
