### PR TITLE
fix: Protect against load balancer service existing

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -59,6 +59,9 @@ PROMETHEUS_PORT = 8080
 PFCP_PORT = 8805
 REQUIRED_CPU_EXTENSIONS = ["avx2", "rdrand"]
 
+# The default field manager set when using kubectl to create resources
+DEFAULT_FIELD_MANAGER = "controller"
+
 
 class IncompatibleCPUError(Exception):
     """Custom error to be raised when CPU doesn't support required instructions."""
@@ -168,8 +171,8 @@ class UPFOperatorCharm(CharmBase):
             ),
         )
 
-        client.create(service)
-        logger.info("Created external UPF service")
+        client.apply(service, field_manager=DEFAULT_FIELD_MANAGER)
+        logger.info("Created/asserted existence of the external UPF service")
 
     def _on_remove(self, event: RemoveEvent) -> None:
         self._delete_external_upf_service()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -693,7 +693,9 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
-        patch_client.return_value.create.assert_called_once_with(expected_service)
+        patch_client.return_value.apply.assert_called_once_with(
+            expected_service, field_manager="controller"
+        )
 
     @patch("charm.Client")
     def test_when_remove_then_external_service_is_deleted(self, patch_client):


### PR DESCRIPTION
In case something happens to cause our charm to go down without properly cleaning up the service, use `client.apply()` instead of client.create()`.

`apply()` will ensure the service configuration matches what is expected, but is OK if it already exists, unlike `create()` which will throw an error if the service already exists.

This will also prevent errors when scaling up (even though scaling isn't supported at this time).

# Description

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
