### PR TITLE
fix: use internal UPF hostname when MetalLB is not available

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -737,11 +737,11 @@ class UPFOperatorCharm(CharmBase):
     def _get_external_upf_hostname_config(self) -> Optional[str]:
         return self.model.config.get("external-upf-hostname")
 
-    def _upf_load_balancer_service_hostname(self) -> str:
+    def _upf_load_balancer_service_hostname(self) -> Optional[str]:
         """Returns the hostname of UPF's LoadBalancer service.
 
         Returns:
-            str: Hostname of UPF's LoadBalancer service
+            str/None: Hostname of UPF's LoadBalancer service if available else None
         """
         client = Client()
         service = client.get(
@@ -749,13 +749,13 @@ class UPFOperatorCharm(CharmBase):
         )
         try:
             return service.status.loadBalancer.ingress[0].hostname  # type: ignore[attr-defined]
-        except AttributeError:
+        except (AttributeError, TypeError):
             logger.error(
                 "Service '%s-external' does not have a hostname:\n%s",
                 self.model.app.name,
                 service,
             )
-            return ""
+            return None
 
     @property
     def _upf_hostname(self) -> str:


### PR DESCRIPTION
# Description

This PR aims to fix #55. The fix catches the `TypeError` exception thrown when trying to access ingress information when MetalLB is not enabled or properly configured, allowing the charm to use the internal UPF hostname as expected.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
