### PR TITLE
fix: Reconfigure bessd on restart

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -470,14 +470,16 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             bool:   True/False
         """
-        return self._bessd_container.exists(
-            path=f"{BESSD_CONTAINER_CONFIG_PATH}/{BESSCTL_CONFIGURE_EXECUTED_FILE_NAME}"
-        )
+        return self._bessd_container.exists(path=f"/{BESSCTL_CONFIGURE_EXECUTED_FILE_NAME}")
 
     def _create_bessctl_executed_validation_file(self, content) -> None:
-        """This creates BESSCTL_CONFIGURE_EXECUTED_FILE_NAME under BESSD_CONTAINER_CONFIG_PATH."""
+        """Create BESSCTL_CONFIGURE_EXECUTED_FILE_NAME.
+
+        This must be created outside of the persistent storage volume so that
+        on container restart, bessd configuration will run again.
+        """
         self._bessd_container.push(
-            path=f"{BESSD_CONTAINER_CONFIG_PATH}/{BESSCTL_CONFIGURE_EXECUTED_FILE_NAME}",
+            path=f"/{BESSCTL_CONFIGURE_EXECUTED_FILE_NAME}",
             source=content,
         )
         logger.info("Pushed %s configuration check file", BESSCTL_CONFIGURE_EXECUTED_FILE_NAME)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -311,7 +311,7 @@ class TestCharm(unittest.TestCase):
     def test_given_connects_and_bessctl_executed_file_exists_then_bessctl_configure_not_executed(
         self, patch_is_ready
     ):
-        (self.root / "etc/bess/conf/bessctl_configure_executed").write_text("")
+        (self.root / "bessctl_configure_executed").write_text("")
 
         bessctl_called = False
 


### PR DESCRIPTION
# Description

Moves the state file that is used as a semaphore away from the persistent volume and into the container ephemeral storage so the test for configuration completed does not prevent config on restart

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- N/A I have made corresponding changes to the documentation
- N/A I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- N/A Any dependent changes have been merged and published in downstream modules
- N/A I have bumped the version of the library
