### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test-with-multus.yaml@main
     with:
-      charm-file-name: "sdcore-upf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-upf-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -37,7 +37,7 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-upf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-upf-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit
 
   fiveg-n3-lib-needs-publishing:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           filters: |
             fiveg_n3:
-              - 'lib/charms/sdcore_upf/v0/fiveg_n3.py'
+              - 'lib/charms/sdcore_upf_k8s/v0/fiveg_n3.py'
 
   publish-fiveg-n3-lib:
     name: Publish Lib
@@ -61,7 +61,7 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@main
     with:
-      lib-name: "charms.sdcore_upf.v0.fiveg_n3"
+      lib-name: "charms.sdcore_upf_k8s.v0.fiveg_n3"
     secrets: inherit
 
   fiveg-n4-lib-needs-publishing:
@@ -75,7 +75,7 @@ jobs:
         with:
           filters: |
             fiveg_n4:
-              - 'lib/charms/sdcore_upf/v0/fiveg_n4.py'
+              - 'lib/charms/sdcore_upf_k8s/v0/fiveg_n4.py'
 
   publish-fiveg-n4-lib:
     name: Publish Lib
@@ -85,5 +85,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@main
     with:
-      lib-name: "charms.sdcore_upf.v0.fiveg_n4"
+      lib-name: "charms.sdcore_upf_k8s.v0.fiveg_n4"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core UPF K8s Operator
+# SD-Core UPF Operator for K8s
 [![CharmHub Badge](https://charmhub.io/sdcore-upf-k8s/badge.svg)](https://charmhub.io/sdcore-upf-k8s)
 
-Charmed K8s Operator for SD-Core's User Plane Function (UPF). For more information, read [here](https://github.com/omec-project/upf).
+Charmed Operator for SD-Core's User Plane Function (UPF) for K8s. For more information, read [here](https://github.com/omec-project/upf).
 
 ## Pre-requisites
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core UPF Operator for K8s
+# SD-Core UPF Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-upf-k8s/badge.svg)](https://charmhub.io/sdcore-upf-k8s)
 
 Charmed Operator for SD-Core's User Plane Function (UPF) for K8s. For more information, read [here](https://github.com/omec-project/upf).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core UPF Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-upf/badge.svg)](https://charmhub.io/sdcore-upf)
+# SD-Core UPF K8s Operator
+[![CharmHub Badge](https://charmhub.io/sdcore-upf-k8s/badge.svg)](https://charmhub.io/sdcore-upf-k8s)
 
-Charmed Operator for SD-Core's User Plane Function (UPF). For more information, read [here](https://github.com/omec-project/upf).
+Charmed K8s Operator for SD-Core's User Plane Function (UPF). For more information, read [here](https://github.com/omec-project/upf).
 
 ## Pre-requisites
 
@@ -27,7 +27,7 @@ juju add-model user-plane
 Deploy the UPF:
 
 ```bash
-juju deploy sdcore-upf --trust --channel=edge
+juju deploy sdcore-upf-k8s --trust --channel=edge
 ```
 
 ### Exposing the UPF externally

--- a/lib/charms/sdcore_upf_k8s/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf_k8s/v0/fiveg_n4.py
@@ -1,80 +1,85 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Library for the `fiveg_n3` relation.
+"""Library for the `fiveg_n4` relation.
 
-This library offers a way of providing and consuming an IP address of the SDCORE's UPF.
-In a typical 5G network, UPF's IP address is consumed by the gNodeBs, in order to establish
-communication over the N3 interface.
+This library contains the Requires and Provides classes for handling the `fiveg_n4`
+interface.
+
+The purpose of this library is to integrate a charm claiming to be able to provide
+information required to establish communication over the N4 interface with a charm
+claiming to be able to consume this information.
 
 To get started using the library, you need to fetch the library using `charmcraft`.
 
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.sdcore_upf.v0.fiveg_n3
+charmcraft fetch-lib charms.sdcore_upf_k8s.v0.fiveg_n4
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
 - pydantic
 - pytest-interface-tester
 
-Charms providing the `fiveg_n3` relation should use `N3Provides`.
+Charms providing the `fiveg_n4` relation should use `N4Provides`.
 Typical usage of this class would look something like:
 
     ```python
     ...
-    from charms.sdcore_upf.v0.fiveg_n3 import N3Provides
+    from charms.sdcore_upf_k8s.v0.fiveg_n4 import N4Provides
     ...
 
     class SomeProviderCharm(CharmBase):
 
         def __init__(self, *args):
             ...
-            self.fiveg_n3 = N3Provides(charm=self, relation_name="fiveg_n3")
+            self.fiveg_n4 = N4Provides(charm=self, relation_name="fiveg_n4")
             ...
-            self.framework.observe(self.fiveg_n3.on.fiveg_n3_request, self._on_fiveg_n3_request)
+            self.framework.observe(self.fiveg_n4.on.fiveg_n4_request, self._on_fiveg_n4_request)
 
-        def _on_fiveg_n3_request(self, event):
+        def _on_fiveg_n4_request(self, event):
             ...
-            self.fiveg_n3.publish_upf_information(
+            self.fiveg_n4.publish_upf_n4_information(
                 relation_id=event.relation_id,
-                upf_ip_address=ip_address,
+                upf_hostname=hostname,
+                upf_port=n4_port,
             )
     ```
 
     And a corresponding section in charm's `metadata.yaml`:
     ```
     provides:
-        fiveg_n3:  # Relation name
-            interface: fiveg_n3  # Relation interface
+        fiveg_n4:  # Relation name
+            interface: fiveg_n4  # Relation interface
     ```
 
-Charms that require the `fiveg_n3` relation should use `N3Requires`.
+Charms that require the `fiveg_n4` relation should use `N4Requires`.
 Typical usage of this class would look something like:
 
     ```python
     ...
-    from charms.sdcore_upf.v0.fiveg_n3 import N3Requires
+    from charms.sdcore_upf_k8s.v0.fiveg_n4 import N4Requires
     ...
 
     class SomeRequirerCharm(CharmBase):
 
         def __init__(self, *args):
             ...
-            self.fiveg_n3 = N3Requires(charm=self, relation_name="fiveg_n3")
+            self.fiveg_n4 = N4Requires(charm=self, relation_name="fiveg_n4")
             ...
-            self.framework.observe(self.upf.on.fiveg_n3_available, self._on_fiveg_n3_available)
+            self.framework.observe(self.upf.on.fiveg_n4_available, self._on_fiveg_n4_available)
 
-        def _on_fiveg_n3_available(self, event):
-            upf_ip_address = event.upf_ip_address
-            # Do something with the UPF's IP address
+        def _on_fiveg_n4_available(self, event):
+            upf_hostname = event.upf_hostname,
+            upf_port = event.upf_port,
+            # Do something with the UPF's hostname and port
     ```
 
     And a corresponding section in charm's `metadata.yaml`:
     ```
     requires:
-        fiveg_n3:  # Relation name
-            interface: fiveg_n3  # Relation interface
+        fiveg_n4:  # Relation name
+            interface: fiveg_n4  # Relation interface
     ```
 """
 
@@ -83,24 +88,24 @@ import logging
 from interface_tester.schema_base import DataBagSchema  # type: ignore[import]
 from ops.charm import CharmBase, CharmEvents, RelationChangedEvent, RelationJoinedEvent
 from ops.framework import EventBase, EventSource, Object
-from pydantic import BaseModel, Field, IPvAnyAddress, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "4b9dbfa97f7849dda91d47f5cb0fa044"
+LIBID = "6c81534a04904d48966ceb7b4f42a850"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 1
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 
 
 logger = logging.getLogger(__name__)
 
-"""Schemas definition for the provider and requirer sides of the `fiveg_n3` interface.
+"""Schemas definition for the provider and requirer sides of the `fiveg_n4` interface.
 It exposes two interfaces.schema_base.DataBagSchema subclasses called:
 - ProviderSchema
 - RequirerSchema
@@ -108,7 +113,8 @@ Examples:
     ProviderSchema:
         unit: <empty>
         app: {
-            "upf_ip_address": "1.2.3.4"
+            "upf_hostname": "upf.uplane-cloud.canonical.com",
+            "upf_port": 8805
         }
     RequirerSchema:
         unit: <empty>
@@ -116,16 +122,23 @@ Examples:
 """
 
 
-class ProviderAppData(BaseModel):
-    """Provider app data for fiveg_n3."""
+class FivegN4ProviderAppData(BaseModel):
+    """Provider app data for fiveg_n4."""
 
-    upf_ip_address: IPvAnyAddress = Field(description="UPF IP address", examples=["1.2.3.4"])
+    upf_hostname: str = Field(
+        description="Name of the host exposing the UPF's N4 interface.",
+        examples=["upf.uplane-cloud.canonical.com"],
+    )
+    upf_port: int = Field(
+        description="Port on which UPF's N4 interface is exposed.",
+        examples=[8805],
+    )
 
 
 class ProviderSchema(DataBagSchema):
-    """Provider schema for fiveg_n3."""
+    """Provider schema for fiveg_n4."""
 
-    app: ProviderAppData
+    app: FivegN4ProviderAppData
 
 
 def data_matches_provider_schema(data: dict) -> bool:
@@ -145,8 +158,8 @@ def data_matches_provider_schema(data: dict) -> bool:
         return False
 
 
-class FiveGN3RequestEvent(EventBase):
-    """Dataclass for the `fiveg_n3` request event."""
+class FiveGN4RequestEvent(EventBase):
+    """Dataclass for the `fiveg_n4` request event."""
 
     def __init__(self, handle, relation_id: int):
         """Sets relation id."""
@@ -164,16 +177,16 @@ class FiveGN3RequestEvent(EventBase):
         self.relation_id = snapshot["relation_id"]
 
 
-class N3ProviderCharmEvents(CharmEvents):
-    """Custom events for the N3Provider."""
+class N4ProviderCharmEvents(CharmEvents):
+    """Custom events for the N4Provider."""
 
-    fiveg_n3_request = EventSource(FiveGN3RequestEvent)
+    fiveg_n4_request = EventSource(FiveGN4RequestEvent)
 
 
-class N3Provides(Object):
-    """Class to be instantiated by provider of the `fiveg_n3`."""
+class N4Provides(Object):
+    """Class to be instantiated by provider of the `fiveg_n4`."""
 
-    on = N3ProviderCharmEvents()
+    on = N4ProviderCharmEvents()
 
     def __init__(self, charm: CharmBase, relation_name: str):
         """Observes relation joined event.
@@ -187,21 +200,27 @@ class N3Provides(Object):
         super().__init__(charm, relation_name)
         self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_joined)
 
-    def publish_upf_information(self, relation_id: int, upf_ip_address: str) -> None:
-        """Sets UPF's IP address in the relation data.
+    def publish_upf_n4_information(
+        self, relation_id: int, upf_hostname: str, upf_n4_port: int
+    ) -> None:
+        """Sets UPF's hostname and port in the relation data.
 
         Args:
             relation_id (str): Relation ID
-            upf_ip_address (str): UPF's IP address
+            upf_hostname (str): UPF's hostname
+            upf_n4_port (int): Port on which UPF accepts N4 communication
         """
-        if not data_matches_provider_schema(data={"upf_ip_address": upf_ip_address}):
-            raise ValueError(f"Invalid UPF IP address: {upf_ip_address}")
+        if not data_matches_provider_schema(
+            data={"upf_hostname": upf_hostname, "upf_port": upf_n4_port}
+        ):
+            raise ValueError(f"Invalid UPF N4 data: {upf_hostname}, {upf_n4_port}")
         relation = self.model.get_relation(
             relation_name=self.relation_name, relation_id=relation_id
         )
         if not relation:
             raise RuntimeError(f"Relation {self.relation_name} not created yet.")
-        relation.data[self.charm.app]["upf_ip_address"] = upf_ip_address
+        relation.data[self.charm.app]["upf_hostname"] = upf_hostname
+        relation.data[self.charm.app]["upf_port"] = str(upf_n4_port)
 
     def _on_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Triggered whenever a requirer charm joins the relation.
@@ -209,36 +228,41 @@ class N3Provides(Object):
         Args:
             event (RelationJoinedEvent): Juju event
         """
-        self.on.fiveg_n3_request.emit(relation_id=event.relation.id)
+        self.on.fiveg_n4_request.emit(relation_id=event.relation.id)
 
 
-class N3AvailableEvent(EventBase):
-    """Dataclass for the `fiveg_n3` available event."""
+class N4AvailableEvent(EventBase):
+    """Dataclass for the `fiveg_n4` available event."""
 
-    def __init__(self, handle, upf_ip_address: str):
-        """Sets certificate."""
+    def __init__(self, handle, upf_hostname: str, upf_port: int):
+        """Sets UPF's hostname and port."""
         super().__init__(handle)
-        self.upf_ip_address = upf_ip_address
+        self.upf_hostname = upf_hostname
+        self.upf_port = upf_port
 
     def snapshot(self) -> dict:
         """Returns event data."""
-        return {"upf_ip_address": self.upf_ip_address}
+        return {
+            "upf_hostname": self.upf_hostname,
+            "upf_port": self.upf_port,
+        }
 
     def restore(self, snapshot):
         """Restores event data."""
-        self.upf_ip_address = snapshot["upf_ip_address"]
+        self.upf_hostname = snapshot["upf_hostname"]
+        self.upf_port = snapshot["upf_port"]
 
 
-class N3RequirerCharmEvents(CharmEvents):
-    """Custom events for the N3Requirer."""
+class N4RequirerCharmEvents(CharmEvents):
+    """Custom events for the N4Requirer."""
 
-    fiveg_n3_available = EventSource(N3AvailableEvent)
+    fiveg_n4_available = EventSource(N4AvailableEvent)
 
 
-class N3Requires(Object):
-    """Class to be instantiated by requirer of the `fiveg_n3`."""
+class N4Requires(Object):
+    """Class to be instantiated by requirer of the `fiveg_n4`."""
 
-    on = N3RequirerCharmEvents()
+    on = N4RequirerCharmEvents()
 
     def __init__(self, charm: CharmBase, relation_name: str):
         """Observes relation joined and relation changed events.
@@ -260,6 +284,7 @@ class N3Requires(Object):
             event (RelationChangedEvent): Juju event
         """
         relation_data = event.relation.data
-        upf_ip_address = relation_data[event.app].get("upf_ip_address")  # type: ignore[index]
-        if upf_ip_address:
-            self.on.fiveg_n3_available.emit(upf_ip_address=upf_ip_address)
+        upf_hostname = relation_data[event.app].get("upf_hostname")  # type: ignore[index]
+        upf_port = relation_data[event.app].get("upf_port")  # type: ignore[index]
+        if upf_hostname and upf_port:
+            self.on.fiveg_n4_available.emit(upf_hostname=upf_hostname, upf_port=upf_port)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,10 +1,10 @@
-name: sdcore-upf
-display-name: SD-Core 5G UPF
+name: sdcore-upf-k8s
+display-name: SD-Core 5G UPF K8s
 summary: Charmed Operator for SD-Core's User Plane Function (UPF).
 description: Charmed Operator for SD-Core's User Plane Function (UPF).
-website: https://charmhub.io/sdcore-upf
-source: https://github.com/canonical/sdcore-upf-operator
-issues: https://github.com/canonical/sdcore-upf-operator/issues
+website: https://charmhub.io/sdcore-upf-k8s
+source: https://github.com/canonical/sdcore-upf-k8s-operator
+issues: https://github.com/canonical/sdcore-upf-k8s-operator/issues
 
 containers:
   bessd:

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed K8s operator for the SD-Core UPF service."""
+"""Charmed operator for the SD-Core UPF service for K8s."""
 
 import ipaddress
 import json
@@ -81,8 +81,8 @@ class UpfOperatorCharmEvents(CharmEvents):
     hugepages_volumes_config_changed = EventSource(K8sHugePagesVolumePatchChangedEvent)
 
 
-class UPFK8sOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the 5G UPF K8s operator."""
+class UPFOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the 5G UPF operator for K8s."""
 
     on = UpfOperatorCharmEvents()
 
@@ -976,4 +976,4 @@ def ip_is_valid(ip_address: str) -> bool:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(UPFK8sOperatorCharm)
+    main(UPFOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,8 +23,8 @@ from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import
 from charms.prometheus_k8s.v0.prometheus_scrape import (  # type: ignore[import]
     MetricsEndpointProvider,
 )
-from charms.sdcore_upf.v0.fiveg_n3 import N3Provides  # type: ignore[import]
-from charms.sdcore_upf.v0.fiveg_n4 import N4Provides  # type: ignore[import]
+from charms.sdcore_upf_k8s.v0.fiveg_n3 import N3Provides  # type: ignore[import]
+from charms.sdcore_upf_k8s.v0.fiveg_n4 import N4Provides  # type: ignore[import]
 from jinja2 import Environment, FileSystemLoader
 from lightkube.core.client import Client
 from lightkube.models.core_v1 import ServicePort, ServiceSpec

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the SD-Core UPF service."""
+"""Charmed K8s operator for the SD-Core UPF service."""
 
 import ipaddress
 import json
@@ -81,8 +81,8 @@ class UpfOperatorCharmEvents(CharmEvents):
     hugepages_volumes_config_changed = EventSource(K8sHugePagesVolumePatchChangedEvent)
 
 
-class UPFOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the 5G UPF operator."""
+class UPFK8sOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the 5G UPF K8s operator."""
 
     on = UpfOperatorCharmEvents()
 
@@ -976,4 +976,4 @@ def ip_is_valid(ip_address: str) -> bool:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(UPFOperatorCharm)
+    main(UPFK8sOperatorCharm)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@ flake8-docstrings
 flake8-builtins
 isort
 juju
-macaroonbakery==1.3.2
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/unit/expected_upf.json
+++ b/tests/unit/expected_upf.json
@@ -9,7 +9,7 @@
   "cpiface": {
     "dnn": "internet",
     "enable_ue_ip_alloc": false,
-    "hostname": "sdcore-upf-external.whatever.svc.cluster.local",
+    "hostname": "sdcore-upf-k8s-external.whatever.svc.cluster.local",
     "http_port": "8080"
   },
   "enable_notify_bess": true,

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_provider_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_provider_charm/src/charm.py
@@ -3,8 +3,8 @@
 
 import logging
 
-from charms.sdcore_upf.v0.fiveg_n3 import N3Provides
-from charms.sdcore_upf.v0.fiveg_n4 import N4Provides
+from charms.sdcore_upf_k8s.v0.fiveg_n3 import N3Provides
+from charms.sdcore_upf_k8s.v0.fiveg_n4 import N4Provides
 from ops.charm import CharmBase
 from ops.main import main
 

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_requirer_charm/src/charm.py
@@ -3,8 +3,8 @@
 
 import logging
 
-from charms.sdcore_upf.v0.fiveg_n3 import N3Requires
-from charms.sdcore_upf.v0.fiveg_n4 import N4Requires
+from charms.sdcore_upf_k8s.v0.fiveg_n3 import N3Requires
+from charms.sdcore_upf_k8s.v0.fiveg_n4 import N4Requires
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_requirer.py
@@ -15,7 +15,7 @@ class TestN3Requires(unittest.TestCase):
         self.harness.begin()
         self.relation_name = "fiveg_n3"
 
-    @patch("charms.sdcore_upf.v0.fiveg_n3.N3RequirerCharmEvents.fiveg_n3_available")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3RequirerCharmEvents.fiveg_n3_available")
     def test_given_relation_with_n3_provider_when_fiveg_n3_available_event_then_n3_information_is_provided(  # noqa: E501
         self, patched_fiveg_n3_available_event
     ):

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
@@ -15,7 +15,7 @@ class TestN4Requires(unittest.TestCase):
         self.harness.begin()
         self.relation_name = "fiveg_n4"
 
-    @patch("charms.sdcore_upf.v0.fiveg_n4.N4RequirerCharmEvents.fiveg_n4_available")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4RequirerCharmEvents.fiveg_n4_available")
     def test_given_relation_with_n4_provider_when_fiveg_n4_available_event_then_n4_information_is_provided(  # noqa: E501
         self, patched_fiveg_n4_available_event
     ):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -451,7 +451,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("charms.sdcore_upf.v0.fiveg_n3.N3Provides.publish_upf_information")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
     def test_given_fiveg_n3_relation_created_when_fiveg_n3_request_then_upf_ip_address_is_published(  # noqa: E501
         self,
         patched_publish_upf_information,
@@ -468,7 +468,7 @@ class TestCharm(unittest.TestCase):
             relation_id=n3_relation_id, upf_ip_address=test_upf_access_ip_cidr.split("/")[0]
         )
 
-    @patch("charms.sdcore_upf.v0.fiveg_n3.N3Provides.publish_upf_information")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
     def test_given_unit_is_not_leader_when_fiveg_n3_request_then_upf_ip_address_is_not_published(
         self, patched_publish_upf_information
     ):
@@ -482,7 +482,7 @@ class TestCharm(unittest.TestCase):
         patched_publish_upf_information.assert_not_called()
 
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
-    @patch("charms.sdcore_upf.v0.fiveg_n3.N3Provides.publish_upf_information")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_fiveg_n3_relation_exists_when_access_ip_config_changed_then_new_upf_ip_address_is_published(  # noqa: E501
@@ -508,7 +508,7 @@ class TestCharm(unittest.TestCase):
 
         patched_publish_upf_information.assert_has_calls(expected_calls)
 
-    @patch("charms.sdcore_upf.v0.fiveg_n3.N3Provides.publish_upf_information")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_fiveg_n3_relation_exists_when_access_ip_config_changed_to_invalid_cidr_then_new_upf_ip_address_is_not_published(  # noqa: E501
         self, patch_multus_is_ready, patched_publish_upf_information
@@ -527,7 +527,7 @@ class TestCharm(unittest.TestCase):
             relation_id=n3_relation_id, upf_ip_address="192.168.252.3"
         )
 
-    @patch("charms.sdcore_upf.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     def test_given_unit_is_not_leader_when_fiveg_n4_request_then_upf_hostname_is_not_published(
         self, patched_publish_upf_n4_information
     ):
@@ -543,7 +543,7 @@ class TestCharm(unittest.TestCase):
         patched_publish_upf_n4_information.assert_not_called()
 
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("charms.sdcore_upf.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_set_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
         self,
@@ -567,7 +567,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
-    @patch("charms.sdcore_upf.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_but_external_upf_service_hostname_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
         self, patched_publish_upf_n4_information, patched_lightkube_client_get
@@ -593,7 +593,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
-    @patch("charms.sdcore_upf.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_and_external_upf_service_hostname_not_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
         self, patched_publish_upf_n4_information, patched_lightkube_client_get
@@ -613,7 +613,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
-    @patch("charms.sdcore_upf.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_and_metallb_not_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
         self, patched_publish_upf_n4_information, patched_lightkube_client_get
@@ -631,7 +631,7 @@ class TestCharm(unittest.TestCase):
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("charms.sdcore_upf.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     @patch("charm.PFCP_PORT", TEST_PFCP_PORT)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,7 +14,7 @@ from lightkube.resources.core_v1 import Service
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
-from charm import IncompatibleCPUError, UPFOperatorCharm
+from charm import IncompatibleCPUError, UPFK8sOperatorCharm
 
 MULTUS_LIBRARY_PATH = "charms.kubernetes_charm_libraries.v0.multus"
 HUGEPAGES_LIBRARY_PATH = "charms.kubernetes_charm_libraries.v0.hugepages_volumes_patch"
@@ -63,7 +63,7 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient")
     def setUp(self, patch_k8s_client):
         self.namespace = "whatever"
-        self.harness = testing.Harness(UPFOperatorCharm)
+        self.harness = testing.Harness(UPFK8sOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.harness.set_leader(is_leader=True)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,7 +14,7 @@ from lightkube.resources.core_v1 import Service
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
-from charm import IncompatibleCPUError, UPFK8sOperatorCharm
+from charm import IncompatibleCPUError, UPFOperatorCharm
 
 MULTUS_LIBRARY_PATH = "charms.kubernetes_charm_libraries.v0.multus"
 HUGEPAGES_LIBRARY_PATH = "charms.kubernetes_charm_libraries.v0.hugepages_volumes_patch"
@@ -63,7 +63,7 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient")
     def setUp(self, patch_k8s_client):
         self.namespace = "whatever"
-        self.harness = testing.Harness(UPFK8sOperatorCharm)
+        self.harness = testing.Harness(UPFOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.harness.set_leader(is_leader=True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = lint, static, unit
 src_path = {toxinidir}/src/
 unit_test_path = {toxinidir}/tests/unit/
 integration_test_path = {toxinidir}/tests/integration/
-lib_path = {toxinidir}/lib/charms/sdcore_upf/v0/
+lib_path = {toxinidir}/lib/charms/sdcore_upf_k8s/v0/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path} {[vars]lib_path}
 
 [testenv]


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit) .

- Create new fiveg_n3 and fiveg_n4 libraries
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
