### PR TITLE
feat: Set IP masquerade in the UPF configuration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -411,12 +411,13 @@ class UPFOperatorCharm(CharmBase):
         Writes configuration file, creates routes, creates iptable rule and pebble layer.
         """
         restart = False
+        core_ip_address = self._get_core_network_ip_config()
         content = render_bessd_config_file(
             upf_hostname=self._upf_hostname,
             upf_mode=UPF_MODE,
             access_interface_name=ACCESS_INTERFACE_NAME,
             core_interface_name=CORE_INTERFACE_NAME,
-            core_ip_address=self._get_core_network_ip_config(),
+            core_ip_address=core_ip_address.split("/")[0] if core_ip_address else "",
             dnn=self._get_dnn_config(),  # type: ignore[arg-type]
             pod_share_path=POD_SHARE_PATH,
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -416,6 +416,7 @@ class UPFOperatorCharm(CharmBase):
             upf_mode=UPF_MODE,
             access_interface_name=ACCESS_INTERFACE_NAME,
             core_interface_name=CORE_INTERFACE_NAME,
+            core_ip_address=self._get_core_network_ip_config(),
             dnn=self._get_dnn_config(),  # type: ignore[arg-type]
             pod_share_path=POD_SHARE_PATH,
         )
@@ -909,6 +910,7 @@ def render_bessd_config_file(
     upf_mode: str,
     access_interface_name: str,
     core_interface_name: str,
+    core_ip_address: Optional[str],
     dnn: str,
     pod_share_path: str,
 ) -> str:
@@ -919,6 +921,7 @@ def render_bessd_config_file(
         upf_mode: UPF mode
         access_interface_name: Access network interface name
         core_interface_name: Core network interface name
+        core_ip_address: Core network IP address
         dnn: Data Network Name (DNN)
         pod_share_path: pod_share path
     """
@@ -929,6 +932,7 @@ def render_bessd_config_file(
         mode=upf_mode,
         access_interface_name=access_interface_name,
         core_interface_name=core_interface_name,
+        core_ip_address=core_ip_address,
         dnn=dnn,
         pod_share_path=pod_share_path,
     )

--- a/src/templates/upf.json.j2
+++ b/src/templates/upf.json.j2
@@ -3,7 +3,8 @@
     "ifname": "{{ access_interface_name }}"
   },
   "core": {
-    "ifname": "{{ core_interface_name }}"
+    "ifname": "{{ core_interface_name }}",
+    "ip_masquerade": "{{ core_ip_address }}"
   },
   "cpiface": {
     "dnn": "{{ dnn }}",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ flake8-docstrings
 flake8-builtins
 isort
 juju
+macaroonbakery==1.3.2
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/unit/expected_upf.json
+++ b/tests/unit/expected_upf.json
@@ -3,7 +3,8 @@
     "ifname": "access"
   },
   "core": {
-    "ifname": "core"
+    "ifname": "core",
+    "ip_masquerade": "192.168.250.3/24"
   },
   "cpiface": {
     "dnn": "internet",

--- a/tests/unit/expected_upf.json
+++ b/tests/unit/expected_upf.json
@@ -4,7 +4,7 @@
   },
   "core": {
     "ifname": "core",
-    "ip_masquerade": "192.168.250.3/24"
+    "ip_masquerade": "192.168.250.3"
   },
   "cpiface": {
     "dnn": "internet",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -67,6 +67,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_model_name(name=self.namespace)
         self.harness.set_leader(is_leader=True)
 
+        self.maxDiff = None
         self.root = self.harness.get_filesystem_root("bessd")
         (self.root / "etc/bess/conf").mkdir(parents=True)
         self.addCleanup(self.harness.cleanup)
@@ -88,7 +89,7 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", [], result=0)
         self.harness.container_pebble_ready(container_name="bessd")
 
-        expected_config_file_content = read_file("tests/unit/expected_upf.json")
+        expected_config_file_content = read_file("tests/unit/expected_upf.json").strip()
 
         self.assertEqual(
             (self.root / "etc/bess/conf/upf.json").read_text(), expected_config_file_content
@@ -105,7 +106,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_storage(storage_name="config", count=1)
         self.harness.attach_storage(storage_id="config/0")
 
-        expected_config_file_content = read_file("tests/unit/expected_upf.json")
+        expected_config_file_content = read_file("tests/unit/expected_upf.json").strip()
 
         self.assertEqual(
             (self.root / "etc/bess/conf/upf.json").read_text(), expected_config_file_content
@@ -118,7 +119,7 @@ class TestCharm(unittest.TestCase):
     ):
         self.harness.handle_exec("bessd", [], result=0)
         patch_is_ready.return_value = True
-        expected_upf_content = read_file("tests/unit/expected_upf.json")
+        expected_upf_content = read_file("tests/unit/expected_upf.json").strip()
         (self.root / "etc/bess/conf/upf.json").write_text(expected_upf_content)
 
         self.harness.container_pebble_ready(container_name="bessd")


### PR DESCRIPTION
# Description

Sets IP masquerade on the core interface of the UPF. This will automatically NAT UE traffic to appear to come from the UPF's core interface, making it simpler to integrate in existing networks.

The alternative is to have the core router know about the UE IP pool to be able to route back traffic towards the UPF.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
