### PR TITLE
feat: Add upf config file generation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,6 @@ options:
     type: string
     default: internet
     description: Data Network Name (DNN)
-
   enable-hw-checksum:
     type: boolean
     default: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,23 @@
+options:
+  dnn:
+    type: string
+    default: internet
+    description: Data Network Name (DNN)
+
+  enable-hw-checksum:
+    type: boolean
+    default: true
+    description: |
+      When enabled, hardware checksum will be used on the network interfaces.
+  access-interface-name:
+    type: string
+    default: eth0
+    description: Name of the UPF's access interface.
+  core-interface-name:
+    type: string
+    default: eth1
+    description: Name of the UPF's core interface.
+  core-ip:
+    type: string
+    default: 192.168.250.3/24
+    description: IP address used by the UPF's Core interface.

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,2 @@
+jinja2
 ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements.in
 #
+jinja2==3.1.3
+    # via -r requirements.in
+markupsafe==2.1.5
+    # via jinja2
 ops==2.10.0
     # via -r requirements.in
 pyyaml==6.0.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,18 +4,62 @@
 
 """Machine charm for SD-Core User Plane Function."""
 
+import json
 import logging
+from typing import Optional
 
 import ops
 from charms.operator_libs_linux.v2 import snap
+from jinja2 import Environment, FileSystemLoader
+from machine import Machine
 from ops.model import ActiveStatus, BlockedStatus
 
 UPF_SNAP_NAME = "sdcore-upf"
 UPF_SNAP_CHANNEL = "latest/edge"
 UPF_SNAP_REVISION = "3"
-
+CONFIG_FILE_NAME = "upf.json"
+ACCESS_INTERFACE_NAME = "access"
+CORE_INTERFACE_NAME = "core"
+BESSD_CONFIG_PATH = "/var/snap/sdcore-upf/common"
 
 logger = logging.getLogger(__name__)
+
+
+def render_bessd_config_file(
+    upf_hostname: str,
+    upf_mode: str,
+    access_interface_name: str,
+    core_interface_name: str,
+    core_ip_address: Optional[str],
+    dnn: str,
+    pod_share_path: str,
+    enable_hw_checksum: bool,
+) -> str:
+    """Render the configuration file for the 5G UPF service.
+
+    Args:
+        upf_hostname: UPF hostname
+        upf_mode: UPF mode
+        access_interface_name: Access network interface name
+        core_interface_name: Core network interface name
+        core_ip_address: Core network IP address
+        dnn: Data Network Name (DNN)
+        pod_share_path: pod_share path
+        enable_hw_checksum: Whether to enable hardware checksum or not
+    """
+    jinja2_environment = Environment(loader=FileSystemLoader("src/templates/"))
+    template = jinja2_environment.get_template(f"{CONFIG_FILE_NAME}.j2")
+    content = template.render(
+        upf_hostname=upf_hostname,
+        mode=upf_mode,
+        access_interface_name=access_interface_name,
+        core_interface_name=core_interface_name,
+        core_ip_address=core_ip_address,
+        dnn=dnn,
+        pod_share_path=pod_share_path,
+        hwcksum=str(enable_hw_checksum).lower(),
+    )
+    return content
 
 
 class SdcoreUpfCharm(ops.CharmBase):
@@ -23,6 +67,7 @@ class SdcoreUpfCharm(ops.CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
+        self._machine = Machine()
         self.framework.observe(self.on.install, self._configure)
         self.framework.observe(self.on.update_status, self._configure)
         self.framework.observe(self.on.config_changed, self._configure)
@@ -33,10 +78,11 @@ class SdcoreUpfCharm(ops.CharmBase):
             self.unit.status = BlockedStatus("Scaling is not implemented for this charm")
             return
         self._install_upf_snap()
+        self._generate_upf_config_file()
         self.unit.status = ActiveStatus()
 
     def _install_upf_snap(self) -> None:
-        """Installs the UPF snap in the machine."""
+        """Install the UPF snap in the machine."""
         try:
             snap_cache = snap.SnapCache()
             upf_snap = snap_cache[UPF_SNAP_NAME]
@@ -51,6 +97,64 @@ class SdcoreUpfCharm(ops.CharmBase):
         except snap.SnapError as e:
             logger.error("An exception occurred when installing the UPF snap. Reason: %s", str(e))
             raise e
+
+    def _generate_upf_config_file(self) -> None:
+        """Generate the UPF configuration file."""
+        core_ip_address = self._get_core_network_ip_config()
+        content = render_bessd_config_file(
+            upf_hostname=self._get_upf_hostname(),
+            upf_mode=self._get_upf_mode(),
+            access_interface_name=ACCESS_INTERFACE_NAME,
+            core_interface_name=CORE_INTERFACE_NAME,
+            core_ip_address=core_ip_address.split("/")[0] if core_ip_address else "",
+            dnn=self._get_dnn_config(),
+            pod_share_path=BESSD_CONFIG_PATH,
+            enable_hw_checksum=self._get_enable_hw_checksum(),
+        )
+        if not self._upf_config_file_is_written() or not self._upf_config_file_content_matches(
+            content=content
+        ):
+            self._write_upf_config_file(content=content)
+
+    def _upf_config_file_is_written(self) -> bool:
+        """Return whether the UPF config file was written to the workload.
+
+        Returns:
+            bool: Whether the UPF config file was written
+        """
+        return self._machine.exists(path=f"{BESSD_CONFIG_PATH}/{CONFIG_FILE_NAME}")
+
+    def _upf_config_file_content_matches(self, content: str) -> bool:
+        """Return whether the UPF config file content matches the provided content.
+
+        Returns:
+            bool: Whether the UPF config file content matches
+        """
+        existing_content = self._machine.pull(path=f"{BESSD_CONFIG_PATH}/{CONFIG_FILE_NAME}")
+        try:
+            return json.loads(existing_content) == json.loads(content)
+        except json.JSONDecodeError:
+            return False
+
+    def _write_upf_config_file(self, content: str) -> None:
+        """Write the UPF config file to the workload."""
+        self._machine.push(path=f"{BESSD_CONFIG_PATH}/{CONFIG_FILE_NAME}", source=content)
+        logger.info("Pushed %s config file", CONFIG_FILE_NAME)
+
+    def _get_core_network_ip_config(self) -> str:
+        return "192.168.250.3/24"
+
+    def _get_upf_hostname(self) -> str:
+        return "0.0.0.0"
+
+    def _get_upf_mode(self) -> str:
+        return "af_packet"
+
+    def _get_dnn_config(self) -> str:
+        return "internet"
+
+    def _get_enable_hw_checksum(self) -> bool:
+        return True
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,9 +17,9 @@ from ops.model import ActiveStatus, BlockedStatus
 UPF_SNAP_NAME = "sdcore-upf"
 UPF_SNAP_CHANNEL = "latest/edge"
 UPF_SNAP_REVISION = "3"
-CONFIG_FILE_NAME = "upf.json"
-ACCESS_INTERFACE_NAME = "access"
-CORE_INTERFACE_NAME = "core"
+UPF_CONFIG_FILE_NAME = "upf.json"
+UPF_ACCESS_INTERFACE_NAME = "access"
+UPF_CORE_INTERFACE_NAME = "core"
 UPF_CONFIG_PATH = "/var/snap/sdcore-upf/common"
 
 logger = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ def render_upf_config_file(
         enable_hw_checksum: Whether to enable hardware checksum or not
     """
     jinja2_environment = Environment(loader=FileSystemLoader("src/templates/"))
-    template = jinja2_environment.get_template(f"{CONFIG_FILE_NAME}.j2")
+    template = jinja2_environment.get_template(f"{UPF_CONFIG_FILE_NAME}.j2")
     content = template.render(
         upf_hostname=upf_hostname,
         mode=upf_mode,
@@ -104,8 +104,8 @@ class SdcoreUpfCharm(ops.CharmBase):
         content = render_upf_config_file(
             upf_hostname=self._get_upf_hostname(),
             upf_mode=self._get_upf_mode(),
-            access_interface_name=ACCESS_INTERFACE_NAME,
-            core_interface_name=CORE_INTERFACE_NAME,
+            access_interface_name=UPF_ACCESS_INTERFACE_NAME,
+            core_interface_name=UPF_CORE_INTERFACE_NAME,
             core_ip_address=core_ip_address.split("/")[0] if core_ip_address else "",
             dnn=self._get_dnn_config(),
             pod_share_path=UPF_CONFIG_PATH,
@@ -117,20 +117,12 @@ class SdcoreUpfCharm(ops.CharmBase):
             self._write_upf_config_file(content=content)
 
     def _upf_config_file_is_written(self) -> bool:
-        """Return whether the UPF config file was written to the workload.
-
-        Returns:
-            bool: Whether the UPF config file was written
-        """
-        return self._machine.exists(path=f"{UPF_CONFIG_PATH}/{CONFIG_FILE_NAME}")
+        """Return whether the UPF config file was written to the workload."""
+        return self._machine.exists(path=f"{UPF_CONFIG_PATH}/{UPF_CONFIG_FILE_NAME}")
 
     def _upf_config_file_content_matches(self, content: str) -> bool:
-        """Return whether the UPF config file content matches the provided content.
-
-        Returns:
-            bool: Whether the UPF config file content matches
-        """
-        existing_content = self._machine.pull(path=f"{UPF_CONFIG_PATH}/{CONFIG_FILE_NAME}")
+        """Return whether the UPF config file content matches the provided content."""
+        existing_content = self._machine.pull(path=f"{UPF_CONFIG_PATH}/{UPF_CONFIG_FILE_NAME}")
         try:
             return json.loads(existing_content) == json.loads(content)
         except json.JSONDecodeError:
@@ -138,8 +130,8 @@ class SdcoreUpfCharm(ops.CharmBase):
 
     def _write_upf_config_file(self, content: str) -> None:
         """Write the UPF config file to the workload."""
-        self._machine.push(path=f"{UPF_CONFIG_PATH}/{CONFIG_FILE_NAME}", source=content)
-        logger.info("Pushed %s config file", CONFIG_FILE_NAME)
+        self._machine.push(path=f"{UPF_CONFIG_PATH}/{UPF_CONFIG_FILE_NAME}", source=content)
+        logger.info("Pushed %s config file", UPF_CONFIG_FILE_NAME)
 
     def _get_core_network_ip_config(self) -> str:
         return "192.168.250.3/24"

--- a/src/charm.py
+++ b/src/charm.py
@@ -39,11 +39,11 @@ class SdcoreUpfCharm(ops.CharmBase):
         if not self.unit.is_leader():
             self.unit.status = BlockedStatus("Scaling is not implemented for this charm")
             return
-        # if invalid_configs := self._get_invalid_configs():
-        #     self.unit.status = BlockedStatus(
-        #         f"The following configurations are not valid: {invalid_configs}"
-        #     )
-        #     return
+        if invalid_configs := self._get_invalid_configs():
+            self.unit.status = BlockedStatus(
+                f"The following configurations are not valid: {invalid_configs}"
+            )
+            return
         self._install_upf_snap()
         self._generate_upf_config_file()
         self.unit.status = ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,12 +20,12 @@ UPF_SNAP_REVISION = "3"
 CONFIG_FILE_NAME = "upf.json"
 ACCESS_INTERFACE_NAME = "access"
 CORE_INTERFACE_NAME = "core"
-BESSD_CONFIG_PATH = "/var/snap/sdcore-upf/common"
+UPF_CONFIG_PATH = "/var/snap/sdcore-upf/common"
 
 logger = logging.getLogger(__name__)
 
 
-def render_bessd_config_file(
+def render_upf_config_file(
     upf_hostname: str,
     upf_mode: str,
     access_interface_name: str,
@@ -101,14 +101,14 @@ class SdcoreUpfCharm(ops.CharmBase):
     def _generate_upf_config_file(self) -> None:
         """Generate the UPF configuration file."""
         core_ip_address = self._get_core_network_ip_config()
-        content = render_bessd_config_file(
+        content = render_upf_config_file(
             upf_hostname=self._get_upf_hostname(),
             upf_mode=self._get_upf_mode(),
             access_interface_name=ACCESS_INTERFACE_NAME,
             core_interface_name=CORE_INTERFACE_NAME,
             core_ip_address=core_ip_address.split("/")[0] if core_ip_address else "",
             dnn=self._get_dnn_config(),
-            pod_share_path=BESSD_CONFIG_PATH,
+            pod_share_path=UPF_CONFIG_PATH,
             enable_hw_checksum=self._get_enable_hw_checksum(),
         )
         if not self._upf_config_file_is_written() or not self._upf_config_file_content_matches(
@@ -122,7 +122,7 @@ class SdcoreUpfCharm(ops.CharmBase):
         Returns:
             bool: Whether the UPF config file was written
         """
-        return self._machine.exists(path=f"{BESSD_CONFIG_PATH}/{CONFIG_FILE_NAME}")
+        return self._machine.exists(path=f"{UPF_CONFIG_PATH}/{CONFIG_FILE_NAME}")
 
     def _upf_config_file_content_matches(self, content: str) -> bool:
         """Return whether the UPF config file content matches the provided content.
@@ -130,7 +130,7 @@ class SdcoreUpfCharm(ops.CharmBase):
         Returns:
             bool: Whether the UPF config file content matches
         """
-        existing_content = self._machine.pull(path=f"{BESSD_CONFIG_PATH}/{CONFIG_FILE_NAME}")
+        existing_content = self._machine.pull(path=f"{UPF_CONFIG_PATH}/{CONFIG_FILE_NAME}")
         try:
             return json.loads(existing_content) == json.loads(content)
         except json.JSONDecodeError:
@@ -138,7 +138,7 @@ class SdcoreUpfCharm(ops.CharmBase):
 
     def _write_upf_config_file(self, content: str) -> None:
         """Write the UPF config file to the workload."""
-        self._machine.push(path=f"{BESSD_CONFIG_PATH}/{CONFIG_FILE_NAME}", source=content)
+        self._machine.push(path=f"{UPF_CONFIG_PATH}/{CONFIG_FILE_NAME}", source=content)
         logger.info("Pushed %s config file", CONFIG_FILE_NAME)
 
     def _get_core_network_ip_config(self) -> str:

--- a/src/machine.py
+++ b/src/machine.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Machine abstraction for machine charms."""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+class Machine:
+    """A class to interact with a unit machine.
+
+    This class has the same method signatures as Pebble API in the Ops
+    Library. This is to improve consistency between the Machine and Kubernetes
+    versions of the charm.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Check if a file exists.
+
+        Args:
+            path: The path of the file
+
+        Returns:
+            bool: Whether the file exists
+        """
+        return os.path.isfile(path)
+
+    def pull(self, path: str) -> str:
+        """Get the content of a file.
+
+        Args:
+            path: The path of the file
+
+        Returns:
+            str: The content of the file
+        """
+        with open(path, "r") as read_file:
+            return read_file.read()
+
+    def push(self, path: str, source: str) -> None:
+        """Pushes a file to the unit.
+
+        Args:
+            path: The path of the file
+            source: The contents of the file to be pushed
+        """
+        with open(path, "w") as write_file:
+            write_file.write(source)
+            logger.info("Pushed file %s", path)

--- a/src/templates/upf.json.j2
+++ b/src/templates/upf.json.j2
@@ -1,0 +1,47 @@
+{
+  "access": {
+    "ifname": "{{ access_interface_name }}"
+  },
+  "core": {
+    "ifname": "{{ core_interface_name }}",
+    "ip_masquerade": "{{ core_ip_address }}"
+  },
+  "cpiface": {
+    "dnn": "{{ dnn }}",
+    "enable_ue_ip_alloc": false,
+    "hostname": "{{ upf_hostname }}",
+    "http_port": "8080"
+  },
+  "enable_notify_bess": true,
+  "gtppsc": true,
+  "hwcksum": {{ hwcksum }},
+  "log_level": "trace",
+  "max_sessions": 50000,
+  "measure_flow": false,
+  "measure_upf": true,
+  "mode": "{{ mode }}",
+  "notify_sockaddr": "{{ pod_share_path }}/notifycp",
+  "qci_qos_config": [
+    {
+      "burst_duration_ms": 10,
+      "cbs": 50000,
+      "ebs": 50000,
+      "pbs": 50000,
+      "priority": 7,
+      "qci": 0
+    }
+  ],
+  "slice_rate_limit_config": {
+    "n3_bps": 1000000000,
+    "n3_burst_bytes": 12500000,
+    "n6_bps": 1000000000,
+    "n6_burst_bytes": 12500000
+  },
+  "table_sizes": {
+    "appQERLookup": 200000,
+    "farLookup": 150000,
+    "pdrLookup": 50000,
+    "sessionQERLookup": 100000
+  },
+  "workers": 1
+}

--- a/tests/unit/expected_upf.json
+++ b/tests/unit/expected_upf.json
@@ -1,9 +1,9 @@
 {
     "access": {
-        "ifname": "access"
+        "ifname": "eth0"
     },
     "core": {
-        "ifname": "core",
+        "ifname": "eth1",
         "ip_masquerade": "192.168.250.3"
     },
     "cpiface": {

--- a/tests/unit/expected_upf.json
+++ b/tests/unit/expected_upf.json
@@ -1,0 +1,47 @@
+{
+    "access": {
+        "ifname": "access"
+    },
+    "core": {
+        "ifname": "core",
+        "ip_masquerade": "192.168.250.3"
+    },
+    "cpiface": {
+        "dnn": "internet",
+        "enable_ue_ip_alloc": false,
+        "hostname": "0.0.0.0",
+        "http_port": "8080"
+    },
+    "enable_notify_bess": true,
+    "gtppsc": true,
+    "hwcksum": true,
+    "log_level": "trace",
+    "max_sessions": 50000,
+    "measure_flow": false,
+    "measure_upf": true,
+    "mode": "af_packet",
+    "notify_sockaddr": "/var/snap/sdcore-upf/common/notifycp",
+    "qci_qos_config": [
+        {
+            "burst_duration_ms": 10,
+            "cbs": 50000,
+            "ebs": 50000,
+            "pbs": 50000,
+            "priority": 7,
+            "qci": 0
+        }
+    ],
+    "slice_rate_limit_config": {
+        "n3_bps": 1000000000,
+        "n3_burst_bytes": 12500000,
+        "n6_bps": 1000000000,
+        "n6_burst_bytes": 12500000
+    },
+    "table_sizes": {
+        "appQERLookup": 200000,
+        "farLookup": 150000,
+        "pdrLookup": 50000,
+        "sessionQERLookup": 100000
+    },
+    "workers": 1
+}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -170,3 +170,12 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config()
 
         assert not self.mock_machine.push_called
+
+    def test_given_invalid_config_when_config_changed_then_status_is_blocked(self):
+        self.harness.set_leader(True)
+        self.harness.update_config({"core-ip": "not an ip address"})
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ops.BlockedStatus("The following configurations are not valid: ['core-ip']"),
+        )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -128,12 +128,9 @@ class TestCharm(unittest.TestCase):
 
     @patch("charms.operator_libs_linux.v2.snap.SnapCache")
     def test_given_config_file_not_written_when_config_changed_then_config_file_is_written(
-        self, mock_snap_cache
+        self, _
     ):
         self.harness.set_leader(True)
-        upf_snap = MockSnapObject("sdcore-upf")
-        snap_cache = {"sdcore-upf": upf_snap}
-        mock_snap_cache.return_value = snap_cache
         self.mock_machine.exists_return_value = False
 
         self.harness.update_config()
@@ -147,12 +144,9 @@ class TestCharm(unittest.TestCase):
 
     @patch("charms.operator_libs_linux.v2.snap.SnapCache")
     def test_given_config_file_written_with_different_content_when_config_changed_then_new_config_file_is_written(
-        self, mock_snap_cache
+        self, _
     ):
         self.harness.set_leader(True)
-        upf_snap = MockSnapObject("sdcore-upf")
-        snap_cache = {"sdcore-upf": upf_snap}
-        mock_snap_cache.return_value = snap_cache
         self.mock_machine.exists_return_value = True
         self.mock_machine.pull_return_value = "initial content"
 
@@ -167,12 +161,9 @@ class TestCharm(unittest.TestCase):
 
     @patch("charms.operator_libs_linux.v2.snap.SnapCache")
     def test_given_config_file_written_with_identical_content_when_config_changed_then_new_config_file_not_written(
-        self, mock_snap_cache
+        self, _
     ):
         self.harness.set_leader(True)
-        upf_snap = MockSnapObject("sdcore-upf")
-        snap_cache = {"sdcore-upf": upf_snap}
-        mock_snap_cache.return_value = snap_cache
         self.mock_machine.exists_return_value = True
         self.mock_machine.pull_return_value = read_file("tests/unit/expected_upf.json").strip()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 import unittest
 from typing import List, Optional
 from unittest.mock import patch
@@ -9,6 +10,20 @@ import ops
 import ops.testing
 from charm import SdcoreUpfCharm
 from charms.operator_libs_linux.v2.snap import SnapState
+
+
+def read_file(path: str) -> str:
+    """Read a file and returns as a string.
+
+    Args:
+        path (str): path to the file.
+
+    Returns:
+        str: content of the file.
+    """
+    with open(path, "r") as f:
+        content = f.read()
+    return content
 
 
 class MockSnapObject:
@@ -38,8 +53,31 @@ class MockSnapObject:
         self.start_called_with = {"services": services, "enable": enable}
 
 
+class MockMachine:
+    def __init__(self, exists_return_value: bool = False, pull_return_value: str = ""):
+        self.exists_return_value = exists_return_value
+        self.pull_return_value = pull_return_value
+        self.push_called = False
+
+    def exists(self, path: str) -> bool:
+        return self.exists_return_value
+
+    def push(self, path: str, source: str) -> None:
+        self.push_called = True
+        self.push_called_with = {"path": path, "source": source}
+
+    def pull(self, path: str) -> str:
+        return self.pull_return_value
+
+    def make_dir(self, path: str) -> None:
+        pass
+
+
 class TestCharm(unittest.TestCase):
-    def setUp(self):
+    @patch("charm.Machine")
+    def setUp(self, patch_machine):
+        self.mock_machine = MockMachine()
+        patch_machine.return_value = self.mock_machine
         self.harness = ops.testing.Harness(SdcoreUpfCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
@@ -87,3 +125,57 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config()
 
         self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+
+    @patch("charms.operator_libs_linux.v2.snap.SnapCache")
+    def test_given_config_file_not_written_when_config_changed_then_config_file_is_written(
+        self, mock_snap_cache
+    ):
+        self.harness.set_leader(True)
+        upf_snap = MockSnapObject("sdcore-upf")
+        snap_cache = {"sdcore-upf": upf_snap}
+        mock_snap_cache.return_value = snap_cache
+        self.mock_machine.exists_return_value = False
+
+        self.harness.update_config()
+
+        expected_config_file_content = read_file("tests/unit/expected_upf.json").strip()
+        assert self.mock_machine.push_called
+        assert json.loads(expected_config_file_content) == json.loads(
+            self.mock_machine.push_called_with["source"]
+        )
+        assert self.mock_machine.push_called_with["path"] == "/var/snap/sdcore-upf/common/upf.json"
+
+    @patch("charms.operator_libs_linux.v2.snap.SnapCache")
+    def test_given_config_file_written_with_different_content_when_config_changed_then_new_config_file_is_written(
+        self, mock_snap_cache
+    ):
+        self.harness.set_leader(True)
+        upf_snap = MockSnapObject("sdcore-upf")
+        snap_cache = {"sdcore-upf": upf_snap}
+        mock_snap_cache.return_value = snap_cache
+        self.mock_machine.exists_return_value = True
+        self.mock_machine.pull_return_value = "initial content"
+
+        self.harness.update_config()
+
+        expected_config_file_content = read_file("tests/unit/expected_upf.json").strip()
+        assert self.mock_machine.push_called
+        assert json.loads(expected_config_file_content) == json.loads(
+            self.mock_machine.push_called_with["source"]
+        )
+        assert self.mock_machine.push_called_with["path"] == "/var/snap/sdcore-upf/common/upf.json"
+
+    @patch("charms.operator_libs_linux.v2.snap.SnapCache")
+    def test_given_config_file_written_with_identical_content_when_config_changed_then_new_config_file_not_written(
+        self, mock_snap_cache
+    ):
+        self.harness.set_leader(True)
+        upf_snap = MockSnapObject("sdcore-upf")
+        snap_cache = {"sdcore-upf": upf_snap}
+        mock_snap_cache.return_value = snap_cache
+        self.mock_machine.exists_return_value = True
+        self.mock_machine.pull_return_value = read_file("tests/unit/expected_upf.json").strip()
+
+        self.harness.update_config()
+
+        assert not self.mock_machine.push_called


### PR DESCRIPTION
# Description

Add the UPF configuration file generation using Jinja template. We also introduce the `machine` abstraction that is responsible for handling everything machine related using the same API as `ops.pebble`.

## Notes
- Currently some values used in the config file are hardcoded (ex. DNN, upf mode, etc.). Those will get configurable through future PR's.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
