### PR TITLE
feat: start upf service

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ juju add-machine ssh:ubuntu@<UPF machine IP address> --private-key id_rsa
 
 ```shell
 juju deploy sdcore-upf \
+  --channel=1.3/edge \
   --config access-interface-name=enp6s0 \
   --config core-interface-name=enp7s0 \
   --to <machine number>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ lxc network create core --type=bridge ipv4.address=192.168.250.1/24
 Deploy a VM using Multipass with the `access` and `core` networks:
 
 ```shell
-multipass launch 22.04 --name upf --network access --network core
+multipass launch 22.04 --name upf --network access --network core --memory 8G --cpus 4
 ```
 
 Add the Machine to the Juju controller:

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,11 +102,12 @@ class SdcoreUpfCharm(ops.CharmBase):
             )
             try:
                 process.wait_output()
+                logger.info("Service `bessd` configured")
+                return
             except ExecError:
                 logger.info("Failed running configuration for bess")
                 time.sleep(2)
-            logger.info("Service `bessd` configured")
-            return
+
         raise TimeoutError("Timed out trying to run configuration for bess")
 
     def _generate_upf_config_file(self) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,7 @@ from upf_network import UPFNetwork
 
 UPF_SNAP_NAME = "sdcore-upf"
 UPF_SNAP_CHANNEL = "latest/edge"
-UPF_SNAP_REVISION = "3"
+UPF_SNAP_REVISION = "7"
 UPF_CONFIG_FILE_NAME = "upf.json"
 UPF_CONFIG_PATH = "/var/snap/sdcore-upf/common"
 

--- a/src/machine.py
+++ b/src/machine.py
@@ -6,8 +6,63 @@
 
 import logging
 import os
+import subprocess
+from typing import IO, AnyStr, Dict, Generic, Optional, Sequence, TextIO, Tuple
 
 logger = logging.getLogger(__name__)
+
+
+class ExecProcess(Generic[AnyStr]):
+    """A class to represent a running process."""
+
+    def __init__(
+        self,
+        stdin: Optional[IO[AnyStr]],
+        stdout: Optional[IO[AnyStr]],
+        stderr: Optional[IO[AnyStr]],
+        timeout: Optional[float],
+        command: Sequence[str],
+        process: subprocess.Popen,
+    ):
+        self.stdin = stdin
+        self.stdout = stdout
+        self.stderr = stderr
+        self._timeout = timeout
+        self._command = command
+        self._process = process
+
+    def wait_output(self) -> Tuple[AnyStr, Optional[AnyStr]]:
+        """Wait for the process to finish and return tuple of (stdout, stderr)."""
+        try:
+            stdout_data, stderr_data = self._process.communicate(timeout=self._timeout)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            stdout_data, stderr_data = self._process.communicate()
+            raise TimeoutError(
+                f"Command '{self._command}' timed out after {self._timeout} seconds"
+            )
+
+        exit_code = self._process.returncode
+        if exit_code != 0:
+            raise ExecError(self._command, exit_code, stdout_data, stderr_data)
+
+        return stdout_data, stderr_data
+
+
+class ExecError(Exception, Generic[AnyStr]):
+    """A class to represent an error when executing a command."""
+
+    def __init__(
+        self,
+        command: Sequence[str],
+        exit_code: int,
+        stdout: Optional[AnyStr],
+        stderr: Optional[AnyStr],
+    ):
+        self.command = command
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
 
 
 class Machine:
@@ -51,3 +106,49 @@ class Machine:
         with open(path, "w") as write_file:
             write_file.write(source)
             logger.info("Pushed file %s", path)
+
+    def exec(
+        self,
+        command: Sequence[str],
+        environment: Optional[Dict[str, str]] = None,
+        working_dir: Optional[str] = None,
+        timeout: Optional[float] = None,
+        user: Optional[str] = None,
+        group: Optional[str] = None,
+        stdin: Optional[TextIO] = None,
+        stdout: Optional[TextIO] = None,
+        stderr: Optional[TextIO] = None,
+    ) -> ExecProcess:
+        """Execute a command on the machine.
+
+        Args:
+            command: The command to execute
+            environment: The environment variables to set
+            working_dir: The working directory to execute the command in
+            timeout: The timeout for the command
+            user: The user to execute the command as
+            group: The group to execute the command as
+            stdin: The standard input for the command
+            stdout: The standard output for the command
+            stderr: The standard error for the command
+        """
+        process = subprocess.Popen(
+            args=command,
+            stdin=stdin,
+            stdout=subprocess.PIPE if stdout is None else stdout,
+            stderr=subprocess.PIPE if stderr is None else stderr,
+            shell=True,
+            cwd=working_dir,
+            env=environment,
+            user=user,
+            group=group,
+            text=True,
+        )
+        return ExecProcess(
+            stdin=stdin,
+            stdout=process.stdout,
+            stderr=process.stderr,
+            timeout=timeout,
+            command=command,
+            process=process,
+        )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -66,7 +66,7 @@ class TestCharm(unittest.TestCase):
         upf_snap.ensure.assert_called_with(
             SnapState.Latest,
             channel="latest/edge",
-            revision="3",
+            revision="7",
             devmode=True,
         )
         upf_snap.hold.assert_called()


### PR DESCRIPTION
# Description

Start UPF service using the `sdcore-upf` snap daemons. This includes extending the `Machine` with `exec` .

## Note
- This PR depends on the `sdcore-upf.bessctl` cli app implemented here: https://github.com/canonical/sdcore-upf-snap/pull/5

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
