### PR TITLE
chore: centralise status management

### DIFF
--- a/src/upf_network.py
+++ b/src/upf_network.py
@@ -209,3 +209,11 @@ class UPFNetwork:
         if not self.ip_tables_rule.exists():
             logger.info("Iptables rule does not exist")
             self.ip_tables_rule.create()
+
+    def is_configured(self) -> bool:
+        """Return whether the network is configured for the UPF service."""
+        return (
+            self.default_route.exists()
+            and self.ran_route.exists()
+            and self.ip_tables_rule.exists()
+        )


### PR DESCRIPTION
# Description

Centralise status management using the new ops "Collect Status" event. We also add validations (`_upf_service_started`, `network.is_configured` to make sure the status properly reflects the state of the charm.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
