### PR TITLE
chore: UPF machine charm integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -34,7 +34,6 @@ jobs:
           
           echo "# Install Multipass"
           /usr/bin/sudo snap install multipass
-          sleep 10  # Time for Multipass to initialize
           while ! multipass set local.driver=lxd; do echo "Retrying setting local.driver for Multipass"; done
           /usr/bin/sudo snap restart multipass.multipassd
           /usr/bin/sudo cp /var/snap/multipass/common/data/multipassd/ssh-keys/id_rsa ~
@@ -61,7 +60,7 @@ jobs:
           juju add-model upf-integration
           
           echo "# Prepare UPF VM"
-          /usr/bin/sudo multipass launch 22.04 --name upf --network access --network core --memory 8G --cpus 4
+          multipass launch 22.04 --name upf --network access --network core --memory 8G --cpus 4
           ssh-keyscan -H $(multipass info upf | grep "IPv4" | awk '{ print $2 }') >> ~/.ssh/known_hosts
           juju add-machine ssh:ubuntu@$(multipass info upf | grep "IPv4" | awk '{ print $2 }') --private-key ~/id_rsa    
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -18,6 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          limit-access-to-actor: true
+
       - name: Setup operator environment
         run: |
           echo "# Configure SSH"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -61,7 +61,7 @@ jobs:
           
           echo "# Bootstrap controller"
           mkdir -p ~/.local/share
-          juju add-cloud upf-local -f ./.github/workflows/resources/upf-local-cloud.yaml || true
+          juju add-cloud upf-local --client -f ./.github/workflows/resources/upf-local-cloud.yaml || true
           juju bootstrap upf-local || true
           juju add-model upf-integration
           

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-#      - name: Setup upterm session
-#        uses: lhotari/action-upterm@v1
-#        with:
-#          limit-access-to-actor: true
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          limit-access-to-actor: true
 
       - name: Setup operator environment
         run: |
@@ -33,14 +33,14 @@ jobs:
           fi
           
           echo "# Initialize LXD"
-          /usr/bin/sudo lxd init --auto
+          lxd init --auto
           lxc network create access --type=bridge ipv4.address=192.168.252.1/24 || true
           lxc network create core --type=bridge ipv4.address=192.168.250.1/24 || true
           
           echo "# Install Multipass"
           /usr/bin/sudo snap install multipass
           sleep 10  # Time for Multipass to initialize
-          multipass set local.driver=lxd
+          /usr/bin/sudo multipass set local.driver=lxd
           /usr/bin/sudo snap restart multipass.multipassd
           /usr/bin/sudo cp /var/snap/multipass/common/data/multipassd/ssh-keys/id_rsa ~
           /usr/bin/sudo chown $USER:$USER ~/id_rsa

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-        with:
-          limit-access-to-actor: true
+#      - name: Setup upterm session
+#        uses: lhotari/action-upterm@v1
+#        with:
+#          limit-access-to-actor: true
 
       - name: Setup operator environment
         run: |
@@ -60,15 +60,15 @@ jobs:
           /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
           
           echo "# Bootstrap controller"
-          mkdir -p /home/ubuntu/.local/share
-          juju add-cloud upf-local -f resources/upf-local-cloud.yaml || true
+          mkdir -p ~/.local/share
+          juju add-cloud upf-local -f ./.github/workflows/resources/upf-local-cloud.yaml || true
           juju bootstrap upf-local || true
           juju add-model upf-integration
           
           echo "# Prepare UPF VM"
-          multipass launch 22.04 --name upf --network access --network core --memory 8G --cpus 4
-          ssh-keyscan -H $(multipass info upf | grep "IPv4" | awk '{ print $2 }') >> ~/.ssh/known_hosts
-          juju add-machine ssh:ubuntu@$(multipass info upf | grep "IPv4" | awk '{ print $2 }') --private-key ~/id_rsa    
+          /usr/bin/sudo multipass launch 22.04 --name upf --network access --network core --memory 8G --cpus 4
+          ssh-keyscan -H $(sudo multipass info upf | grep "IPv4" | awk '{ print $2 }') >> ~/.ssh/known_hosts
+          juju add-machine ssh:ubuntu@$(sudo multipass info upf | grep "IPv4" | awk '{ print $2 }') --private-key ~/id_rsa    
 
       - name: Run integration tests
         run: tox -e integration

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,69 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: Integration test
+
+on:
+  workflow_call:
+    inputs:
+      charm-file-name:
+        description: Tested charm file name
+        required: true
+        type: string
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup operator environment
+        run: |
+          echo "# Configure SSH"
+          if ! [ -f ~/.ssh/id_rsa ]; then
+            ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+            cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+            ssh-copy-id -o StrictHostKeyChecking=no ubuntu@localhost
+          fi
+          
+          echo "# Initialize LXD"
+          /usr/bin/sudo lxd init --auto
+          lxc network create access --type=bridge ipv4.address=192.168.252.1/24 || true
+          lxc network create core --type=bridge ipv4.address=192.168.250.1/24 || true
+          
+          echo "# Install Multipass"
+          /usr/bin/sudo snap install multipass
+          sleep 10  # Time for Multipass to initialize
+          multipass set local.driver=lxd
+          /usr/bin/sudo snap restart multipass.multipassd
+          /usr/bin/sudo cp /var/snap/multipass/common/data/multipassd/ssh-keys/id_rsa ~
+          /usr/bin/sudo chown $USER:$USER ~/id_rsa
+          
+          echo "# Install tox"
+          /usr/bin/sudo apt update -yqq
+          /usr/bin/sudo apt install -yqq python3-pip
+          /usr/bin/sudo pip3 install tox
+
+          echo "# Install Juju"
+          /usr/bin/sudo snap install juju --channel=3.4/stable
+
+          echo "# Install juju-crashdump"
+          /usr/bin/sudo snap install juju-crashdump --classic --channel=latest
+
+          echo "# Install charmcraft"
+          /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
+          
+          echo "# Bootstrap controller"
+          mkdir -p /home/ubuntu/.local/share
+          juju add-cloud upf-local -f resources/upf-local-cloud.yaml || true
+          juju bootstrap upf-local || true
+          juju add-model upf-integration
+          
+          echo "# Prepare UPF VM"
+          multipass launch 22.04 --name upf --network access --network core --memory 8G --cpus 4
+          ssh-keyscan -H $(multipass info upf | grep "IPv4" | awk '{ print $2 }') >> ~/.ssh/known_hosts
+          juju add-machine ssh:ubuntu@$(multipass info upf | grep "IPv4" | awk '{ print $2 }') --private-key ~/id_rsa    
+
+      - name: Run integration tests
+        run: tox -e integration

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -34,7 +34,7 @@ jobs:
           
           echo "# Install Multipass"
           /usr/bin/sudo snap install multipass
-          while ! multipass set local.driver=lxd; do echo "Retrying setting local.driver for Multipass"; done
+          while ! multipass set local.driver=lxd; do sleep 5; echo "Retrying setting local.driver for Multipass"; done
           /usr/bin/sudo snap restart multipass.multipassd
           /usr/bin/sudo cp /var/snap/multipass/common/data/multipassd/ssh-keys/id_rsa ~
           /usr/bin/sudo chown $USER:$USER ~/id_rsa

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -13,15 +13,10 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: upf-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-        with:
-          limit-access-to-actor: true
 
       - name: Setup operator environment
         run: |
@@ -34,13 +29,13 @@ jobs:
           
           echo "# Initialize LXD"
           /usr/bin/sudo lxd init --auto
-          /usr/bin/sudo lxc network create access --type=bridge ipv4.address=192.168.252.1/24 || true
-          /usr/bin/sudo lxc network create core --type=bridge ipv4.address=192.168.250.1/24 || true
+          lxc network create access --type=bridge ipv4.address=192.168.252.1/24 || true
+          lxc network create core --type=bridge ipv4.address=192.168.250.1/24 || true
           
           echo "# Install Multipass"
           /usr/bin/sudo snap install multipass
           sleep 10  # Time for Multipass to initialize
-          /usr/bin/sudo multipass set local.driver=lxd
+          multipass set local.driver=lxd
           /usr/bin/sudo snap restart multipass.multipassd
           /usr/bin/sudo cp /var/snap/multipass/common/data/multipassd/ssh-keys/id_rsa ~
           /usr/bin/sudo chown $USER:$USER ~/id_rsa
@@ -67,8 +62,8 @@ jobs:
           
           echo "# Prepare UPF VM"
           /usr/bin/sudo multipass launch 22.04 --name upf --network access --network core --memory 8G --cpus 4
-          ssh-keyscan -H $(sudo multipass info upf | grep "IPv4" | awk '{ print $2 }') >> ~/.ssh/known_hosts
-          juju add-machine ssh:ubuntu@$(sudo multipass info upf | grep "IPv4" | awk '{ print $2 }') --private-key ~/id_rsa    
+          ssh-keyscan -H $(multipass info upf | grep "IPv4" | awk '{ print $2 }') >> ~/.ssh/known_hosts
+          juju add-machine ssh:ubuntu@$(multipass info upf | grep "IPv4" | awk '{ print $2 }') --private-key ~/id_rsa    
 
       - name: Run integration tests
         run: tox -e integration

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -70,6 +70,28 @@ jobs:
       - name: Run integration tests
         run: tox -e integration
 
+      - name: Archive Tested Charm
+        uses: actions/upload-artifact@v4
+        if: ${{ github.ref_name == 'main' }}
+        with:
+          name: tested-charm
+          path: .tox/**/${{ inputs.charm-file-name }}
+          retention-days: 5
+
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: charmcraft-logs
+          path: /home/runner/.local/state/charmcraft/log/*.log
+
+      - name: Archive juju crashdump
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: juju-crashdump
+          path: juju-crashdump-*.tar.xz
+
       - name: Cleanup Multipass
         if: always()
         run: |

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -60,7 +60,10 @@ jobs:
           juju add-model upf-integration
           
           echo "# Prepare UPF VM"
-          multipass launch 22.04 --name upf --network access --network core --memory 8G --cpus 4
+          while ! multipass launch 22.04 --name upf --network access --network core --memory 8G --cpus 4; do 
+            sleep 5 
+            echo "Retrying VM creation"
+          done
           ssh-keyscan -H $(multipass info upf | grep "IPv4" | awk '{ print $2 }') >> ~/.ssh/known_hosts
           juju add-machine ssh:ubuntu@$(multipass info upf | grep "IPv4" | awk '{ print $2 }') --private-key ~/id_rsa    
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-#      - name: Setup upterm session
-#        uses: lhotari/action-upterm@v1
-#        with:
-#          limit-access-to-actor: true
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          limit-access-to-actor: true
 
       - name: Setup operator environment
         run: |

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -35,7 +35,7 @@ jobs:
           echo "# Install Multipass"
           /usr/bin/sudo snap install multipass
           sleep 10  # Time for Multipass to initialize
-          multipass set local.driver=lxd
+          while ! multipass set local.driver=lxd; do echo "Retrying setting local.driver for Multipass"; done
           /usr/bin/sudo snap restart multipass.multipassd
           /usr/bin/sudo cp /var/snap/multipass/common/data/multipassd/ssh-keys/id_rsa ~
           /usr/bin/sudo chown $USER:$USER ~/id_rsa

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-        with:
-          limit-access-to-actor: true
+#      - name: Setup upterm session
+#        uses: lhotari/action-upterm@v1
+#        with:
+#          limit-access-to-actor: true
 
       - name: Setup operator environment
         run: |
@@ -29,7 +29,7 @@ jobs:
           if ! [ -f ~/.ssh/id_rsa ]; then
             ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
             cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-            ssh-copy-id -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa ubuntu@localhost
+            ssh-copy-id -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa $USER@localhost
           fi
           
           echo "# Initialize LXD"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -24,7 +24,7 @@ jobs:
           if ! [ -f ~/.ssh/id_rsa ]; then
             ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
             cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-            ssh-copy-id -o StrictHostKeyChecking=no ubuntu@localhost
+            ssh-copy-id -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa ubuntu@localhost
           fi
           
           echo "# Initialize LXD"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -64,6 +64,7 @@ jobs:
             sleep 5 
             echo "Retrying VM creation"
           done
+          multipass exec upf -- sudo apt install net-tools
           ssh-keyscan -H $(multipass info upf | grep "IPv4" | awk '{ print $2 }') >> ~/.ssh/known_hosts
           juju add-machine ssh:ubuntu@$(multipass info upf | grep "IPv4" | awk '{ print $2 }') --private-key ~/id_rsa    
 
@@ -97,3 +98,10 @@ jobs:
         run: |
           multipass delete --all
           multipass purge
+
+      - name: Cleanup Juju models
+        if: always()
+        run: |
+          for model in $(juju models | grep test-charm | awk '{ print $1 }'); do
+            juju destroy-model $model --destroy-storage --force --no-wait --no-prompt 
+          done

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,9 +33,9 @@ jobs:
           fi
           
           echo "# Initialize LXD"
-          lxd init --auto
-          lxc network create access --type=bridge ipv4.address=192.168.252.1/24 || true
-          lxc network create core --type=bridge ipv4.address=192.168.250.1/24 || true
+          /usr/bin/sudo lxd init --auto
+          /usr/bin/sudo lxc network create access --type=bridge ipv4.address=192.168.252.1/24 || true
+          /usr/bin/sudo lxc network create core --type=bridge ipv4.address=192.168.250.1/24 || true
           
           echo "# Install Multipass"
           /usr/bin/sudo snap install multipass

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -66,3 +66,9 @@ jobs:
 
       - name: Run integration tests
         run: tox -e integration
+
+      - name: Cleanup Multipass
+        if: always()
+        run: |
+          multipass delete --all
+          multipass purge

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
     uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@main
 
   integration-test:
-    uses: ./integration-tests.yaml
+    uses: ./.github/workflows/integration-tests.yaml
     with:
       charm-file-name: "sdcore-upf_ubuntu-22.04-amd64.charm"
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
     uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@main
 
   integration-test:
-    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test-machine.yaml@main
+    uses: ./integration-tests.yaml
     with:
       charm-file-name: "sdcore-upf_ubuntu-22.04-amd64.charm"
 

--- a/.github/workflows/resources/upf-local-cloud.yaml
+++ b/.github/workflows/resources/upf-local-cloud.yaml
@@ -1,0 +1,7 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+clouds:
+  upf-local:
+    type: manual
+    endpoint: localhost

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -151,7 +151,7 @@ class TestUPFMachineCharm:
             gnb_subnet, access_interface_name
         )
 
-        assert any([re.match(gnb_route_pattern, route) for route in routes.splitlines()])
+        assert any(re.match(gnb_route_pattern, route) for route in routes.splitlines())
 
     @pytest.mark.abort_on_fail
     async def test_given_upf_machine_charm_is_deployed_when_check_routes_then_default_route_for_core_interface_is_set(  # noqa: E501
@@ -163,11 +163,11 @@ class TestUPFMachineCharm:
         charm_config = await application.get_config()
         core_interface_name = charm_config["core-interface-name"]["value"]
         routes = await machine.ssh("ip route")
-        core_default_route_pattern = "^default via \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3} dev %s proto static metric 110" % (  # noqa: E501
+        core_default_route_pattern = "^default via \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3} dev %s proto static metric 110" % (  # noqa: E501, W605
             core_interface_name,
         )
 
-        assert any([re.match(core_default_route_pattern, route) for route in routes.splitlines()])
+        assert any(re.match(core_default_route_pattern, route) for route in routes.splitlines())
 
     @pytest.mark.abort_on_fail
     async def test_given_upf_machine_charm_is_deployed_when_charm_config_changed_then_upf_config_file_is_updated(  # noqa: E501

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -14,13 +14,17 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
+MODEL_NAME = "upf-integration"
 
 
 @pytest.mark.abort_on_fail
-async def test_given_build_when_deploy_on_machine_with_1_interface_than_blocked(ops_test: OpsTest):
+async def test_given_upf_machine_charm_built_when_deploy_than_charm_goes_to_active_status(
+    ops_test: OpsTest
+):
     charm = await ops_test.build_charm(".")
 
-    await asyncio.gather(
-        ops_test.model.deploy(charm, application_name=APP_NAME),
-        ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=1000),
-    )
+    with ops_test.model_context(MODEL_NAME):
+        await asyncio.gather(
+            ops_test.model.deploy(charm, application_name=APP_NAME, to=0),
+            ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000),
+        )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
-MODEL_NAME = "test"
+MODEL_NAME = "upf-integration"
 UPF_CONFIG_FILE_PATH = "/var/snap/sdcore-upf/common/upf.json"
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -105,7 +105,7 @@ async def test_given_upf_machine_charm_is_deployed_when_check_open_ports_then_pf
 
     open_ports = await machine.ssh("netstat -ulnp")
 
-    assert PFCP_PORT in open_ports
+    assert str(PFCP_PORT) in open_ports
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,12 +5,13 @@
 import asyncio
 import json
 import logging
+import os
 import re
 from pathlib import Path
 
 import pytest
 import yaml
-from charm import PFCP_PORT
+from charm import PFCP_PORT, UPF_CONFIG_FILE_NAME, UPF_CONFIG_PATH
 from juju.application import Application
 from juju.machine import Machine
 from juju.model import Model
@@ -21,118 +22,199 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 MODEL_NAME = "upf-integration"
-UPF_CONFIG_FILE_PATH = "/var/snap/sdcore-upf/common/upf.json"
+ACCESS_INTERFACE_NAME = "enp6s0"
+CORE_INTERFACE_NAME = "enp7s0"
 
 
-@pytest.mark.abort_on_fail
-async def test_given_upf_machine_charm_built_when_deploy_than_charm_goes_to_active_status(
-    ops_test: OpsTest
-):
-    charm = await ops_test.build_charm(".")
-    await ops_test.model.connect(model_name=MODEL_NAME)
+class TestUPFMachineCharm:
+    @pytest.fixture(autouse=True)
+    @pytest.mark.abort_on_fail
+    async def setup(self):
+        self.model = Model()
+        await self.model.connect(model_name=MODEL_NAME)
 
-    await asyncio.gather(
-        ops_test.model.deploy(
-            charm,
-            application_name=APP_NAME,
-            config={
-                "access-interface-name": "enp6s0",
-                "core-interface-name": "enp7s0",
-            },
-            to=0,
-        ),
-        ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000),
-    )
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_built_when_deploy_than_charm_goes_to_active_status(
+        self, ops_test: OpsTest
+    ):
+        charm = await ops_test.build_charm(".")
+        await ops_test.model.connect(model_name=MODEL_NAME)
 
+        await asyncio.gather(
+            ops_test.model.deploy(
+                charm,
+                application_name=APP_NAME,
+                config={
+                    "access-interface-name": ACCESS_INTERFACE_NAME,
+                    "core-interface-name": CORE_INTERFACE_NAME,
+                },
+                to=0,
+            ),
+            ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000),
+        )
 
-@pytest.mark.abort_on_fail
-async def test_given_upf_machine_charm_is_deployed_when_inspect_upf_config_file_then_access_and_core_interfaces_match_charm_config():  # noqa: E501
-    machine = await _get_machine("0")
-    application = await _get_application(APP_NAME)
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_is_deployed_when_inspect_upf_config_file_then_access_and_core_interfaces_match_charm_config(  # noqa: E501
+        self,
+    ):
+        machine = await self._get_machine("0")
+        application = await self._get_application(APP_NAME)
 
-    upf_config = await _get_upf_config(machine)
-    charm_config = await application.get_config()
+        upf_config = await self._get_upf_config(machine)
+        charm_config = await application.get_config()
 
-    assert upf_config["access"]["ifname"] == charm_config["access-interface-name"]["value"]
-    assert upf_config["core"]["ifname"] == charm_config["core-interface-name"]["value"]
+        assert upf_config["access"]["ifname"] == charm_config["access-interface-name"]["value"]
+        assert upf_config["core"]["ifname"] == charm_config["core-interface-name"]["value"]
 
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_is_deployed_when_inspect_upf_config_file_then_ip_masquerade_config_matches_core_iface_ip(  # noqa: E501
+        self,
+    ):
+        machine = await self._get_machine("0")
+        application = await self._get_application(APP_NAME)
 
-@pytest.mark.abort_on_fail
-async def test_given_upf_machine_charm_is_deployed_when_inspect_upf_config_file_then_ip_masquerade_config_matches_core_iface_ip():  # noqa: E501
-    machine = await _get_machine("0")
-    application = await _get_application(APP_NAME)
+        upf_config = await self._get_upf_config(machine)
+        charm_config = await application.get_config()
+        core_interface_name = charm_config["core-interface-name"]["value"]
 
-    upf_config = await _get_upf_config(machine)
-    charm_config = await application.get_config()
-    core_interface_name = charm_config["core-interface-name"]["value"]
+        core_iface_info = await machine.ssh(
+            f"ip -f inet addr show {core_interface_name} | grep inet"
+        )
+        core_iface_ip = core_iface_info.split()[1].split("/")[0]
 
-    core_iface_info = await machine.ssh(f"ip -f inet addr show {core_interface_name} | grep inet")
-    core_iface_ip = core_iface_info.split()[1].split("/")[0]
+        assert upf_config["core"]["ip_masquerade"] == core_iface_ip
 
-    assert upf_config["core"]["ip_masquerade"] == core_iface_ip
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_is_deployed_when_inspect_upf_config_file_then_dnn_matches_charm_config(  # noqa: E501
+        self,
+    ):
+        machine = await self._get_machine("0")
+        application = await self._get_application(APP_NAME)
 
+        upf_config = await self._get_upf_config(machine)
+        charm_config = await application.get_config()
 
-@pytest.mark.abort_on_fail
-async def test_given_upf_machine_charm_is_deployed_when_inspect_upf_config_file_then_dnn_matches_charm_config():  # noqa: E501
-    machine = await _get_machine("0")
-    application = await _get_application(APP_NAME)
+        assert upf_config["cpiface"]["dnn"] == charm_config["dnn"]["value"]
 
-    upf_config = await _get_upf_config(machine)
-    charm_config = await application.get_config()
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_is_deployed_when_list_processes_then_upf_processes_are_running(  # noqa: E501
+        self,
+    ):
+        machine = await self._get_machine("0")
+        application = await self._get_application(APP_NAME)
 
-    assert upf_config["cpiface"]["dnn"] == charm_config["dnn"]["value"]
+        charm_config = await application.get_config()
+        access_interface_name = charm_config["access-interface-name"]["value"]
+        core_interface_name = charm_config["core-interface-name"]["value"]
 
+        processes = await machine.ssh("ps aux | grep /snap/sdcore-upf")
 
-@pytest.mark.abort_on_fail
-async def test_given_upf_machine_charm_is_deployed_when_list_processes_then_upf_processes_are_running():  # noqa: E501
-    machine = await _get_machine("0")
-    application = await _get_application(APP_NAME)
+        assert "bessd -f -grpc-url=0.0.0.0:10514 -m 0" in processes
+        assert f"route_control.py -i {access_interface_name} {core_interface_name}" in processes
+        assert (
+            f"pfcpiface -config {os.path.join(UPF_CONFIG_PATH, UPF_CONFIG_FILE_NAME)}" in processes
+        )
 
-    charm_config = await application.get_config()
-    access_interface_name = charm_config["access-interface-name"]["value"]
-    core_interface_name = charm_config["core-interface-name"]["value"]
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_is_deployed_when_check_open_ports_then_pfcp_port_is_listening(  # noqa: E501
+        self,
+    ):
+        machine = await self._get_machine("0")
 
-    processes = await machine.ssh("ps aux | grep /snap/sdcore-upf")
+        open_ports = await machine.ssh("netstat -ulnp")
 
-    assert "bessd -f -grpc-url=0.0.0.0:10514 -m 0" in processes
-    assert f"route_control.py -i {access_interface_name} {core_interface_name}" in processes
-    assert f"pfcpiface -config {UPF_CONFIG_FILE_PATH}" in processes
+        assert str(PFCP_PORT) in open_ports
 
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_is_deployed_when_check_bessd_logs_then_no_errors_in_the_logs(  # noqa: E501
+        self,
+    ):
+        machine = await self._get_machine("0")
 
-@pytest.mark.abort_on_fail
-async def test_given_upf_machine_charm_is_deployed_when_check_open_ports_then_pfcp_port_is_listening():  # noqa: E501
-    machine = await _get_machine("0")
+        bessd_logs = await machine.ssh("journalctl | grep sdcore-upf.bessd | grep -v audit")
 
-    open_ports = await machine.ssh("netstat -ulnp")
+        assert not re.search("error", bessd_logs, re.IGNORECASE)
+        assert not re.search("traceback", bessd_logs, re.IGNORECASE)
 
-    assert str(PFCP_PORT) in open_ports
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_is_deployed_when_check_routes_then_route_to_gnb_subnet_is_set(  # noqa: E501
+        self,
+    ):
+        machine = await self._get_machine("0")
+        application = await self._get_application(APP_NAME)
 
+        charm_config = await application.get_config()
+        gnb_subnet = charm_config["gnb-subnet"]["value"]
+        access_interface_name = charm_config["access-interface-name"]["value"]
+        routes = await machine.ssh("ip route")
+        gnb_route_pattern = "^%s via \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3} dev %s proto static" % (  # noqa: E501, W605
+            gnb_subnet, access_interface_name
+        )
 
-@pytest.mark.abort_on_fail
-async def test_given_upf_machine_charm_is_deployed_when_check_bessd_logs_then_no_errors_in_the_logs():  # noqa: E501
-    machine = await _get_machine("0")
+        assert any([re.match(gnb_route_pattern, route) for route in routes.splitlines()])
 
-    bessd_logs = await machine.ssh("journalctl | grep sdcore-upf.bessd | grep -v audit")
-    logger.error(bessd_logs)
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_is_deployed_when_check_routes_then_default_route_for_core_interface_is_set(  # noqa: E501
+        self,
+    ):
+        machine = await self._get_machine("0")
+        application = await self._get_application(APP_NAME)
 
-    assert not re.search("error", bessd_logs, re.IGNORECASE)
-    assert not re.search("traceback", bessd_logs, re.IGNORECASE)
+        charm_config = await application.get_config()
+        core_interface_name = charm_config["core-interface-name"]["value"]
+        routes = await machine.ssh("ip route")
+        core_default_route_pattern = "^default via \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3} dev %s proto static metric 110" % (  # noqa: E501
+            core_interface_name,
+        )
 
+        assert any([re.match(core_default_route_pattern, route) for route in routes.splitlines()])
 
-async def _get_machine(machine_id: str):
-    model = Model()
-    await model.connect(model_name=MODEL_NAME)
-    return Machine(entity_id=machine_id, model=model)
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_is_deployed_when_charm_config_changed_then_upf_config_file_is_updated(  # noqa: E501
+        self,
+    ):
+        test_dnn_name = "integration"
+        machine = await self._get_machine("0")
+        application = await self._get_application(APP_NAME)
 
+        await application.set_config(config={"dnn": test_dnn_name})
+        await self.model.wait_for_idle(status="active")
+        upf_config = await self._get_upf_config(machine)
 
-async def _get_application(application_name: str):
-    model = Model()
-    await model.connect(model_name=MODEL_NAME)
-    return Application(entity_id=application_name, model=model)
+        assert upf_config["cpiface"]["dnn"] == test_dnn_name
 
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_is_deployed_when_charm_config_changed_to_invalid_then_charm_goes_to_blocked_state(  # noqa: E501
+        self,
+    ):
+        invalid_access_iface_name = "whatever"
+        application = await self._get_application(APP_NAME)
 
-async def _get_upf_config(machine):
-    await machine.scp_from(UPF_CONFIG_FILE_PATH, ".")
-    with open(UPF_CONFIG_FILE_PATH.split("/")[-1], "r") as upf_config_file:
-        upf_config = json.loads(upf_config_file.read())
-    return upf_config
+        await application.set_config(config={"access-interface-name": invalid_access_iface_name})
+        await self.model.wait_for_idle()
+
+        assert application.status == "blocked"
+
+    @pytest.mark.abort_on_fail
+    async def test_given_upf_machine_charm_is_deployed_and_in_blocked_status_when_charm_config_changed_back_to_valid_then_charm_goes_to_active_state(  # noqa: E501
+        self,
+    ):
+        application = await self._get_application(APP_NAME)
+
+        await application.set_config(config={"access-interface-name": ACCESS_INTERFACE_NAME})
+        await self.model.wait_for_idle()
+
+        assert application.status == "active"
+
+    async def _get_machine(self, machine_id: str):
+        return Machine(entity_id=machine_id, model=self.model)
+
+    async def _get_application(self, application_name: str):
+        return Application(entity_id=application_name, model=self.model)
+
+    @staticmethod
+    async def _get_upf_config(machine):
+        await machine.scp_from(os.path.join(UPF_CONFIG_PATH, UPF_CONFIG_FILE_NAME), ".")
+        with open(UPF_CONFIG_FILE_NAME, "r") as upf_config_file:
+            upf_config = json.loads(upf_config_file.read())
+        return upf_config

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -24,8 +24,15 @@ async def test_given_upf_machine_charm_built_when_deploy_than_charm_goes_to_acti
     charm = await ops_test.build_charm(".")
     await ops_test.model.connect(model_name=MODEL_NAME)
 
-    with ops_test.model_context(MODEL_NAME):
-        await asyncio.gather(
-            ops_test.model.deploy(charm, application_name=APP_NAME, to=0),
-            ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000),
-        )
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm,
+            application_name=APP_NAME,
+            config={
+                "access-interface-name": "enp6s0",
+                "core-interface-name": "enp7s0",
+            },
+            to=0,
+        ),
+        ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000),
+    )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -22,6 +22,7 @@ async def test_given_upf_machine_charm_built_when_deploy_than_charm_goes_to_acti
     ops_test: OpsTest
 ):
     charm = await ops_test.build_charm(".")
+    await ops_test.model.connect(model_name=MODEL_NAME)
 
     with ops_test.model_context(MODEL_NAME):
         await asyncio.gather(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,18 +3,25 @@
 # See LICENSE file for licensing details.
 
 import asyncio
+import json
 import logging
+import re
 from pathlib import Path
 
 import pytest
 import yaml
+from charm import PFCP_PORT
+from juju.application import Application
+from juju.machine import Machine
+from juju.model import Model
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
-MODEL_NAME = "upf-integration"
+MODEL_NAME = "test"
+UPF_CONFIG_FILE_PATH = "/var/snap/sdcore-upf/common/upf.json"
 
 
 @pytest.mark.abort_on_fail
@@ -36,3 +43,96 @@ async def test_given_upf_machine_charm_built_when_deploy_than_charm_goes_to_acti
         ),
         ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000),
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_given_upf_machine_charm_is_deployed_when_inspect_upf_config_file_then_access_and_core_interfaces_match_charm_config():  # noqa: E501
+    machine = await _get_machine("0")
+    application = await _get_application(APP_NAME)
+
+    upf_config = await _get_upf_config(machine)
+    charm_config = await application.get_config()
+
+    assert upf_config["access"]["ifname"] == charm_config["access-interface-name"]["value"]
+    assert upf_config["core"]["ifname"] == charm_config["core-interface-name"]["value"]
+
+
+@pytest.mark.abort_on_fail
+async def test_given_upf_machine_charm_is_deployed_when_inspect_upf_config_file_then_ip_masquerade_config_matches_core_iface_ip():  # noqa: E501
+    machine = await _get_machine("0")
+    application = await _get_application(APP_NAME)
+
+    upf_config = await _get_upf_config(machine)
+    charm_config = await application.get_config()
+    core_interface_name = charm_config["core-interface-name"]["value"]
+
+    core_iface_info = await machine.ssh(f"ip -f inet addr show {core_interface_name} | grep inet")
+    core_iface_ip = core_iface_info.split()[1].split("/")[0]
+
+    assert upf_config["core"]["ip_masquerade"] == core_iface_ip
+
+
+@pytest.mark.abort_on_fail
+async def test_given_upf_machine_charm_is_deployed_when_inspect_upf_config_file_then_dnn_matches_charm_config():  # noqa: E501
+    machine = await _get_machine("0")
+    application = await _get_application(APP_NAME)
+
+    upf_config = await _get_upf_config(machine)
+    charm_config = await application.get_config()
+
+    assert upf_config["cpiface"]["dnn"] == charm_config["dnn"]["value"]
+
+
+@pytest.mark.abort_on_fail
+async def test_given_upf_machine_charm_is_deployed_when_list_processes_then_upf_processes_are_running():  # noqa: E501
+    machine = await _get_machine("0")
+    application = await _get_application(APP_NAME)
+
+    charm_config = await application.get_config()
+    access_interface_name = charm_config["access-interface-name"]["value"]
+    core_interface_name = charm_config["core-interface-name"]["value"]
+
+    processes = await machine.ssh("ps aux | grep /snap/sdcore-upf")
+
+    assert "bessd -f -grpc-url=0.0.0.0:10514 -m 0" in processes
+    assert f"route_control.py -i {access_interface_name} {core_interface_name}" in processes
+    assert f"pfcpiface -config {UPF_CONFIG_FILE_PATH}" in processes
+
+
+@pytest.mark.abort_on_fail
+async def test_given_upf_machine_charm_is_deployed_when_check_open_ports_then_pfcp_port_is_listening():  # noqa: E501
+    machine = await _get_machine("0")
+
+    open_ports = await machine.ssh("netstat -ulnp")
+
+    assert PFCP_PORT in open_ports
+
+
+@pytest.mark.abort_on_fail
+async def test_given_upf_machine_charm_is_deployed_when_check_bessd_logs_then_no_errors_in_the_logs():  # noqa: E501
+    machine = await _get_machine("0")
+
+    bessd_logs = await machine.ssh("journalctl | grep sdcore-upf.bessd | grep -v audit")
+    logger.error(bessd_logs)
+
+    assert not re.search("error", bessd_logs, re.IGNORECASE)
+    assert not re.search("traceback", bessd_logs, re.IGNORECASE)
+
+
+async def _get_machine(machine_id: str):
+    model = Model()
+    await model.connect(model_name=MODEL_NAME)
+    return Machine(entity_id=machine_id, model=model)
+
+
+async def _get_application(application_name: str):
+    model = Model()
+    await model.connect(model_name=MODEL_NAME)
+    return Application(entity_id=application_name, model=model)
+
+
+async def _get_upf_config(machine):
+    await machine.scp_from(UPF_CONFIG_FILE_PATH, ".")
+    with open(UPF_CONFIG_FILE_PATH.split("/")[-1], "r") as upf_config_file:
+        upf_config = json.loads(upf_config_file.read())
+    return upf_config


### PR DESCRIPTION
# Description

- Changes the environment for the integration tests
  - PS5-based self-hosted runners have been added to the project
  - New integration workflow will create a Multipass VM on the self-hosted runner and use it for deploying the UPF machine charm
- Adds some basic integration tests for the machine charm

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
