### PR TITLE
fix: stop services on removal only if they exist

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -111,9 +111,9 @@ class SdcoreUpfCharm(ops.CharmBase):
         """Stop the upf services and uninstall snap."""
         snap_cache = SnapCache()
         upf_snap = snap_cache[UPF_SNAP_NAME]
-        upf_snap.stop(services=["bessd"])
-        upf_snap.stop(services=["routectl"])
-        upf_snap.stop(services=["pfcpiface"])
+        for service in ["bessd", "routectl", "pfcpiface"]:
+            if upf_snap.services.get(service):
+                upf_snap.stop(services=[service])
         upf_snap.ensure(SnapState.Absent)
 
     def _on_fiveg_n4_request(self, event) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -103,6 +103,44 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.SnapCache")
+    def test_given_upf_services_started_when_remove_then_services_stopped(
+        self, mock_snap_cache
+    ):
+        self.harness.set_leader(True)
+        upf_snap = MagicMock()
+        upf_snap.services = {
+            "bessd": {"active": True},
+            "routectl": {"active": True},
+            "pfcpiface": {"active": True},
+        }
+        snap_cache = {"sdcore-upf": upf_snap}
+        mock_snap_cache.return_value = snap_cache
+
+        self.harness.charm.on.remove.emit()
+
+        upf_snap.stop.assert_has_calls(
+            calls=[
+                call(services=["bessd"]),
+                call(services=["routectl"]),
+                call(services=["pfcpiface"]),
+            ]
+        )
+
+    @patch("charm.SnapCache")
+    def test_given_upf_snap_uninstalled_when_remove_then_services_not_stopped(
+            self, mock_snap_cache
+    ):
+        self.harness.set_leader(True)
+        upf_snap = MagicMock()
+        upf_snap.services = {}
+        snap_cache = {"sdcore-upf": upf_snap}
+        mock_snap_cache.return_value = snap_cache
+
+        self.harness.charm.on.remove.emit()
+
+        upf_snap.stop.assert_not_called()
+
+    @patch("charm.SnapCache")
     def test_given_bessd_not_configured_when_config_changed_then_bessctl_run_called(
         self, mock_snap_cache
     ):


### PR DESCRIPTION
# Description

This PR aims to fix #29, by checking that services exist before stopping them.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
