### PR TITLE
fix: Increase timeout for bessctl command in gRPC readiness check

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -93,15 +93,19 @@ jobs:
           name: juju-crashdump
           path: juju-crashdump-*.tar.xz
 
-      - name: Cleanup Multipass
-        if: always()
-        run: |
-          multipass delete --all
-          multipass purge
-
       - name: Cleanup Juju models
         if: always()
         run: |
+          juju destroy-model upf-integration --destroy-storage --force --no-wait --no-prompt || true
           for model in $(juju models | grep test-charm | awk '{ print $1 }'); do
             juju destroy-model $model --destroy-storage --force --no-wait --no-prompt 
           done
+
+      - name: Cleanup Multipass
+        if: always()
+        run: |
+          while ! multipass delete --all; do 
+            sleep 5 
+            echo "Retrying VM deletion"
+          done
+          multipass purge

--- a/src/charm.py
+++ b/src/charm.py
@@ -252,7 +252,7 @@ class SdcoreUpfCharm(ops.CharmBase):
         command = "sdcore-upf.bessctl show version"
         process = self._machine.exec(
             command=command,
-            timeout=2,
+            timeout=10,
         )
         try:
             process.wait_output()


### PR DESCRIPTION
# Description

This PR aims to fix #34 by increasing the `timeout` parameter for command execution in the gRPC readiness check method.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
