### PR TITLE
chore: ignore major updates for pydantic

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "chore: "
+    ignore:
+      - dependency-name: "pydantic"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
# Description

This PR aims to block dependabot to try to bump the major version of pydantic.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
