### PR TITLE
fix: run integration tests on static juju model

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,4 +51,4 @@ commands =
 [testenv:integration]
 description = Run integration tests
 commands =
-    pytest --asyncio-mode=auto -v --tb native {[vars]integration_test_path} --log-cli-level=INFO -s {posargs}
+    pytest --asyncio-mode=auto -v --tb native {[vars]integration_test_path} --log-cli-level=INFO -s {posargs} --crash-dump=on-failure --model=upf-integration


### PR DESCRIPTION
# Description

This PR aims to fix #41. It instructs `pytest-operator` to run on the already existing `upf-integration` juju model, so `juju-crashdump` will collect logs from the correct model (only on failure).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
