### PR TITLE
chore: bump to v1.4.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,5 +34,5 @@ jobs:
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
       charm-file-name: "sdcore-upf_ubuntu-22.04-amd64.charm"
-      track-name: 1.3
+      track-name: 1.4
     secrets: inherit

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -14,7 +14,7 @@ on:
         type: choice
         description: Name of the charmhub track to publish
         options:
-          - 1.3
+          - 1.4
           - latest
 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ juju add-machine ssh:ubuntu@<UPF machine IP address> --private-key id_rsa
 
 ```shell
 juju deploy sdcore-upf \
-  --channel=1.3/edge \
+  --channel=1.4/edge \
   --config access-interface-name=enp6s0 \
   --config core-interface-name=enp7s0 \
   --to <machine number>

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,7 +27,7 @@ from upf_network import UPFNetwork
 
 UPF_SNAP_NAME = "sdcore-upf"
 UPF_SNAP_CHANNEL = "latest/edge"
-UPF_SNAP_REVISION = "28"
+UPF_SNAP_REVISION = "36"
 UPF_CONFIG_FILE_NAME = "upf.json"
 UPF_CONFIG_PATH = "/var/snap/sdcore-upf/common"
 PFCP_PORT = 8805

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -73,7 +73,7 @@ class TestCharm(unittest.TestCase):
         upf_snap.ensure.assert_called_with(
             SnapState.Latest,
             channel="latest/edge",
-            revision="28",
+            revision="36",
             devmode=True,
         )
         upf_snap.hold.assert_called()


### PR DESCRIPTION
# Description

Bump workload to v1.4.0 and publish charm to `1.4/edge` on Charmhub.

## Note

The charmhub `1.4` track was requested and created:
- https://discourse.charmhub.io/t/create-a-1-4-track-for-sd-core-charms/13790/2

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
