### PR TITLE
chore: enable ruff line length check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ line-length = 99
 [tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "D", "I001"]
 extend-ignore = [
+    "D107",
     "D203",
     "D204",
     "D213",
@@ -28,7 +29,6 @@ extend-ignore = [
     "D409",
     "D413",
 ]
-ignore = ["E501", "D107"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.lint.mccabe]

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -220,7 +220,7 @@ class TestUPFMachineCharm:
         assert application.status == "active"
 
     @pytest.mark.abort_on_fail
-    async def test_given_grafana_agent_deployed_when_relate_to_grafana_agent_then_status_is_active(self, deploy_grafana_agent):
+    async def test_given_grafana_agent_deployed_when_relate_to_grafana_agent_then_status_is_active(self, deploy_grafana_agent):  # noqa: E501
         application = await self._get_application(APP_NAME)
         await self.model.integrate(
             relation1=f"{APP_NAME}:cos-agent",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -216,7 +216,7 @@ class TestCharm(unittest.TestCase):
         assert json.loads(kwargs["source"]) == json.loads(expected_config_file_content)
 
     @patch("charm.SnapCache")
-    def test_given_config_file_written_with_different_content_when_config_changed_then_new_config_file_is_written(
+    def test_given_config_file_written_with_different_content_when_config_changed_then_new_config_file_is_written(  # noqa: E501
         self, _
     ):
         self.harness.set_leader(True)
@@ -231,7 +231,7 @@ class TestCharm(unittest.TestCase):
         assert json.loads(kwargs["source"]) == json.loads(expected_config_file_content)
 
     @patch("charm.SnapCache")
-    def test_given_config_file_written_with_identical_content_when_config_changed_then_new_config_file_not_written(
+    def test_given_config_file_written_with_identical_content_when_config_changed_then_new_config_file_not_written(  # noqa: E501
         self, _
     ):
         self.harness.set_leader(True)

--- a/tests/unit/test_upf_network.py
+++ b/tests/unit/test_upf_network.py
@@ -125,7 +125,7 @@ class TestNetworkInterface(unittest.TestCase):
 
         self.assertEqual(address, interface_ipv4_address)
 
-    def test_given_interface_doesnt_exist_when_get_interface_ip_address_then_empty_string_is_returned(
+    def test_given_interface_doesnt_exist_when_get_interface_ip_address_then_empty_string_is_returned(  # noqa: E501
         self,
     ):
         self.network_interface.network_db.interfaces = MockInterfaces(interfaces=[])
@@ -134,7 +134,7 @@ class TestNetworkInterface(unittest.TestCase):
 
         self.assertEqual(address, "")
 
-    def test_given_interface_doesnt_have_ipv4_address_when_get_interface_ip_address_then_empty_string_is_returned(
+    def test_given_interface_doesnt_have_ipv4_address_when_get_interface_ip_address_then_empty_string_is_returned(  # noqa: E501
         self,
     ):
         self.network_interface.network_db.interfaces = MockInterfaces(
@@ -150,7 +150,7 @@ class TestNetworkInterface(unittest.TestCase):
 
         self.assertEqual(address, "")
 
-    def test_given_interface_has_gateway_ip_address_when_get_gateway_ip_address_then_gateway_ip_is_returned(
+    def test_given_interface_has_gateway_ip_address_when_get_gateway_ip_address_then_gateway_ip_is_returned(  # noqa: E501
         self,
     ):
         gateway_ip = "1.2.3.1"
@@ -170,7 +170,7 @@ class TestNetworkInterface(unittest.TestCase):
 
         self.assertEqual(address, gateway_ip)
 
-    def test_given_interface_doesnt_exist_when_get_gateway_ip_address_then_empty_string_is_returned(
+    def test_given_interface_doesnt_exist_when_get_gateway_ip_address_then_empty_string_is_returned(  # noqa: E501
         self,
     ):
         self.network_interface.ip_route = MockIPRoute(routes=[])
@@ -179,7 +179,7 @@ class TestNetworkInterface(unittest.TestCase):
 
         self.assertEqual(address, "")
 
-    def test_given_interface_doesnt_have_gateway_ip_address_when_get_gateway_ip_address_then_empty_string_is_returned(
+    def test_given_interface_doesnt_have_gateway_ip_address_when_get_gateway_ip_address_then_empty_string_is_returned(  # noqa: E501
         self,
     ):
         self.network_interface.ip_route = MockIPRoute(
@@ -256,7 +256,7 @@ class TestNetworkInterface(unittest.TestCase):
 
         self.assertFalse(is_valid)
 
-    def test_given_interface_exists_and_doesnt_have_ipv4_address_when_is_valid_then_false_is_returned(
+    def test_given_interface_exists_and_doesnt_have_ipv4_address_when_is_valid_then_false_is_returned(  # noqa: E501
         self,
     ):
         self.network_interface.network_db.interfaces = MockInterfaces(
@@ -380,7 +380,7 @@ class TestUPFNetwork(unittest.TestCase):
     @patch("upf_network.IPTablesRule")
     @patch("upf_network.Route")
     @patch("upf_network.NetworkInterface")
-    def test_given_invalid_access_interface_when_get_invalid_network_interfaces_then_interface_is_returned(
+    def test_given_invalid_access_interface_when_get_invalid_network_interfaces_then_interface_is_returned(  # noqa: E501
         self, mock_network_interface, _, __
     ):
         mock_access_interface_instance = MagicMock()
@@ -407,7 +407,7 @@ class TestUPFNetwork(unittest.TestCase):
     @patch("upf_network.IPTablesRule")
     @patch("upf_network.Route")
     @patch("upf_network.NetworkInterface")
-    def test_given_valid_interfaces_when_get_invalid_network_interfaces_then_empty_list_is_returned(
+    def test_given_valid_interfaces_when_get_invalid_network_interfaces_then_empty_list_is_returned(  # noqa: E501
         self, mock_network_interface, _, __
     ):
         mock_access_interface_instance = MagicMock()


### PR DESCRIPTION
# Description

Enable line length check (E501) in ruff

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
