### PR TITLE
fix: Control startup order

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -26,8 +26,8 @@ from ops import (
 from upf_network import UPFNetwork
 
 UPF_SNAP_NAME = "sdcore-upf"
-UPF_SNAP_CHANNEL = "latest/edge"
-UPF_SNAP_REVISION = "36"
+UPF_SNAP_CHANNEL = "1.4/edge"
+UPF_SNAP_REVISION = "42"
 UPF_CONFIG_FILE_NAME = "upf.json"
 UPF_CONFIG_PATH = "/var/snap/sdcore-upf/common"
 PFCP_PORT = 8805
@@ -69,7 +69,7 @@ class SdcoreUpfCharm(ops.CharmBase):
         )
         self.framework.observe(self.on.remove, self._on_remove)
 
-    def _on_collect_status(self, event: CollectStatusEvent):
+    def _on_collect_status(self, event: CollectStatusEvent):  # noqa C901
         """Collect unit status."""
         if not self.unit.is_leader():
             event.add_status(BlockedStatus("Scaling is not implemented for this charm"))
@@ -81,9 +81,7 @@ class SdcoreUpfCharm(ops.CharmBase):
             return
         if invalid_network_interfaces := self._network.get_invalid_network_interfaces():
             event.add_status(
-                BlockedStatus(
-                    f"Network interfaces are not valid: {invalid_network_interfaces}"
-                )
+                BlockedStatus(f"Network interfaces are not valid: {invalid_network_interfaces}")
             )
             return
         if not self._network.is_configured():
@@ -92,11 +90,20 @@ class SdcoreUpfCharm(ops.CharmBase):
         if not self._upf_config_file_is_written():
             event.add_status(WaitingStatus("Waiting for UPF configuration file"))
             return
-        if not self._upf_service_started():
-            event.add_status(WaitingStatus("Waiting for UPF service to start"))
+        if not self._bessd_service_started():
+            event.add_status(WaitingStatus("Waiting for bessd service to start"))
             return
         if not self._is_bessd_grpc_service_ready():
             event.add_status(WaitingStatus("Waiting for bessd gRPC service to start"))
+            return
+        if not self._pfcp_service_started():
+            event.add_status(WaitingStatus("Waiting for pcfp service to start"))
+            return
+        if not self._is_bessd_configured():
+            event.add_status(WaitingStatus("Waiting for bessd worker to start"))
+            return
+        if not self._routectl_service_started():
+            event.add_status(WaitingStatus("Waiting for routectl service to start"))
             return
         event.add_status(ActiveStatus())
 
@@ -113,8 +120,10 @@ class SdcoreUpfCharm(ops.CharmBase):
         self._network.configure()
         self._install_upf_snap()
         self._generate_upf_config_file()
-        self._start_upf_service()
-        self._configure_upf_service()
+        self._start_bessd_service()
+        self._configure_bessd_service()
+        self._start_pfcp_service()
+        self._start_routectl_service()
         self._update_fiveg_n4_relation_data()
 
     def _on_remove(self, event: RemoveEvent):
@@ -179,43 +188,64 @@ class SdcoreUpfCharm(ops.CharmBase):
             upf_snap.hold()
             logger.info("UPF snap installed")
         except SnapError as e:
-            logger.error(
-                "An exception occurred when installing the UPF snap. Reason: %s", str(e)
-            )
+            logger.error("An exception occurred when installing the UPF snap. Reason: %s", str(e))
             raise e
 
     def _upf_snap_installed(self) -> bool:
         """Check if the UPF snap is installed."""
         snap_cache = SnapCache()
         upf_snap = snap_cache[UPF_SNAP_NAME]
-        return (
-            upf_snap.state == SnapState.Latest
-            and upf_snap.revision == UPF_SNAP_REVISION
-        )
+        return upf_snap.state == SnapState.Latest and upf_snap.revision == UPF_SNAP_REVISION
 
-    def _start_upf_service(self) -> None:
-        """Start the UPF service."""
-        if self._upf_service_started():
+    def _start_bessd_service(self) -> None:
+        """Start the bessd service."""
+        if self._bessd_service_started():
             return
         snap_cache = SnapCache()
         upf_snap = snap_cache[UPF_SNAP_NAME]
         upf_snap.start(services=["bessd"])
-        upf_snap.start(services=["routectl"])
-        upf_snap.start(services=["pfcpiface"])
-        logger.info("UPF service started")
+        logger.info("UPF bessd service started")
 
-    def _upf_service_started(self) -> bool:
-        """Check if the UPF service is started."""
+    def _start_pfcp_service(self) -> None:
+        """Start the PFCP service."""
+        if self._pfcp_service_started():
+            return
+        snap_cache = SnapCache()
+        upf_snap = snap_cache[UPF_SNAP_NAME]
+        upf_snap.start(services=["pfcpiface"])
+        logger.info("UPF pfcpiface service started")
+
+    def _start_routectl_service(self) -> None:
+        """Start the UPF routectl service."""
+        if self._routectl_service_started():
+            return
+        snap_cache = SnapCache()
+        upf_snap = snap_cache[UPF_SNAP_NAME]
+        upf_snap.start(services=["routectl"])
+        logger.info("UPF routectl service started")
+
+    def _bessd_service_started(self) -> bool:
+        """Check if the bessd service is started."""
         snap_cache = SnapCache()
         upf_snap = snap_cache[UPF_SNAP_NAME]
         upf_services = upf_snap.services
-        return (
-            upf_services["bessd"]["active"]
-            and upf_services["routectl"]["active"]
-            and upf_services["pfcpiface"]["active"]
-        )
+        return upf_services["bessd"]["active"]
 
-    def _configure_upf_service(self) -> None:
+    def _pfcp_service_started(self) -> bool:
+        """Check if the pfcp service is started."""
+        snap_cache = SnapCache()
+        upf_snap = snap_cache[UPF_SNAP_NAME]
+        upf_services = upf_snap.services
+        return upf_services["pfcpiface"]["active"]
+
+    def _routectl_service_started(self) -> bool:
+        """Check if the routectl service is started."""
+        snap_cache = SnapCache()
+        upf_snap = snap_cache[UPF_SNAP_NAME]
+        upf_services = upf_snap.services
+        return upf_services["routectl"]["active"]
+
+    def _configure_bessd_service(self) -> None:
         self._wait_for_bessd_grpc_service_to_be_ready()
         self._run_bess_configuration()
 
@@ -244,9 +274,7 @@ class SdcoreUpfCharm(ops.CharmBase):
 
         while not self._is_bessd_grpc_service_ready():
             if time.time() - initial_time > timeout:
-                raise TimeoutError(
-                    "Timed out waiting for bessd gRPC server to become ready"
-                )
+                raise TimeoutError("Timed out waiting for bessd gRPC server to become ready")
             time.sleep(2)
 
     def _is_bessd_grpc_service_ready(self) -> bool:
@@ -310,9 +338,8 @@ class SdcoreUpfCharm(ops.CharmBase):
             pod_share_path=UPF_CONFIG_PATH,
             enable_hw_checksum=self._charm_config.enable_hw_checksum,
         )
-        if (
-            not self._upf_config_file_is_written()
-            or not self._upf_config_file_content_matches(content=content)
+        if not self._upf_config_file_is_written() or not self._upf_config_file_content_matches(
+            content=content
         ):
             self._write_upf_config_file(content=content)
 
@@ -322,9 +349,7 @@ class SdcoreUpfCharm(ops.CharmBase):
 
     def _upf_config_file_content_matches(self, content: str) -> bool:
         """Return whether the UPF config file content matches the provided content."""
-        existing_content = self._machine.pull(
-            path=f"{UPF_CONFIG_PATH}/{UPF_CONFIG_FILE_NAME}"
-        )
+        existing_content = self._machine.pull(path=f"{UPF_CONFIG_PATH}/{UPF_CONFIG_FILE_NAME}")
         try:
             return json.loads(existing_content) == json.loads(content)
         except json.JSONDecodeError:
@@ -332,9 +357,7 @@ class SdcoreUpfCharm(ops.CharmBase):
 
     def _write_upf_config_file(self, content: str) -> None:
         """Write the UPF config file to the workload."""
-        self._machine.push(
-            path=f"{UPF_CONFIG_PATH}/{UPF_CONFIG_FILE_NAME}", source=content
-        )
+        self._machine.push(path=f"{UPF_CONFIG_PATH}/{UPF_CONFIG_FILE_NAME}", source=content)
         logger.info("Pushed %s config file", UPF_CONFIG_FILE_NAME)
 
     def _get_upf_hostname(self) -> str:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -41,9 +41,7 @@ class TestCharm(unittest.TestCase):
         patch_machine.return_value = self.mock_machine
         self.mock_upf_network = MagicMock()
         self.mock_upf_network.get_invalid_network_interfaces.return_value = []
-        self.mock_upf_network.core_interface.get_ip_address.return_value = (
-            "192.168.250.3"
-        )
+        self.mock_upf_network.core_interface.get_ip_address.return_value = "192.168.250.3"
         patch_network.return_value = self.mock_upf_network
         self.harness = ops.testing.Harness(SdcoreUpfCharm)
         self.addCleanup(self.harness.cleanup)
@@ -72,8 +70,8 @@ class TestCharm(unittest.TestCase):
 
         upf_snap.ensure.assert_called_with(
             SnapState.Latest,
-            channel="latest/edge",
-            revision="36",
+            channel="1.4/edge",
+            revision="42",
             devmode=True,
         )
         upf_snap.hold.assert_called()
@@ -86,8 +84,8 @@ class TestCharm(unittest.TestCase):
         upf_snap = MagicMock()
         upf_snap.services = {
             "bessd": {"active": False},
-            "routectl": {"active": False},
             "pfcpiface": {"active": False},
+            "routectl": {"active": False},
         }
         snap_cache = {"sdcore-upf": upf_snap}
         mock_snap_cache.return_value = snap_cache
@@ -97,15 +95,13 @@ class TestCharm(unittest.TestCase):
         upf_snap.start.assert_has_calls(
             calls=[
                 call(services=["bessd"]),
-                call(services=["routectl"]),
                 call(services=["pfcpiface"]),
+                call(services=["routectl"]),
             ]
         )
 
     @patch("charm.SnapCache")
-    def test_given_upf_services_started_when_remove_then_services_stopped(
-        self, mock_snap_cache
-    ):
+    def test_given_upf_services_started_when_remove_then_services_stopped(self, mock_snap_cache):
         self.harness.set_leader(True)
         upf_snap = MagicMock()
         upf_snap.services = {
@@ -128,7 +124,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.SnapCache")
     def test_given_upf_snap_uninstalled_when_remove_then_services_not_stopped(
-            self, mock_snap_cache
+        self, mock_snap_cache
     ):
         self.harness.set_leader(True)
         upf_snap = MagicMock()
@@ -188,9 +184,7 @@ class TestCharm(unittest.TestCase):
             self.harness.update_config()
 
     @patch("charm.SnapCache")
-    def test_given_unit_is_leader_when_config_changed_then_status_is_active(
-        self, mock_snap_cache
-    ):
+    def test_given_unit_is_leader_when_config_changed_then_status_is_active(self, mock_snap_cache):
         self.harness.set_leader(True)
         upf_snap = MagicMock()
         snap_cache = {"sdcore-upf": upf_snap}
@@ -236,9 +230,7 @@ class TestCharm(unittest.TestCase):
     ):
         self.harness.set_leader(True)
         self.mock_machine.exists.return_value = True
-        self.mock_machine.pull.return_value = read_file(
-            "tests/unit/expected_upf.json"
-        ).strip()
+        self.mock_machine.pull.return_value = read_file("tests/unit/expected_upf.json").strip()
 
         self.harness.update_config()
 
@@ -253,9 +245,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.model.unit.status,
-            ops.BlockedStatus(
-                "The following configurations are not valid: ['gnb-subnet']"
-            ),
+            ops.BlockedStatus("The following configurations are not valid: ['gnb-subnet']"),
         )
 
     @patch("charm.SnapCache")
@@ -276,9 +266,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.SnapCache")
-    def test_given_network_interfaces_valid_when_config_changed_then_routes_are_created(
-        self, _
-    ):
+    def test_given_network_interfaces_valid_when_config_changed_then_routes_are_created(self, _):
         gnb_subnet = "192.168.251.0/24"
         self.harness.set_leader(True)
         self.harness.update_config(
@@ -383,9 +371,7 @@ class TestCharm(unittest.TestCase):
         patched_publish_upf_n4_information.assert_has_calls(expected_calls)
 
     @patch("charm.SnapCache")
-    def test_given_upf_installed_when_remove_then_snap_removed(
-        self, patched_snap_cache
-    ):
+    def test_given_upf_installed_when_remove_then_snap_removed(self, patched_snap_cache):
         self.harness.set_leader(True)
         upf_snap = MagicMock()
         snap_cache = {"sdcore-upf": upf_snap}


### PR DESCRIPTION
# Description

Start each service in order, and configure bess before routectl starts up. This should prevent the hanging in the `up4.bess` script

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- N/A Any dependent changes have been merged and published in downstream modules
- N/A I have bumped the version of the library
