### PR TITLE
feat: add CPU validation

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -400,7 +400,7 @@ class SdcoreUpfCharm(ops.CharmBase):
             logger.info("Failed running `lscpu`: %s", e)
             return []
         cpu_flags = []
-        for cpu_info_item in cpu_info.decode().split("\n"):
+        for cpu_info_item in cpu_info.split("\n"):
             if "Flags:" in cpu_info_item:
                 cpu_flags = cpu_info_item.split()
                 del cpu_flags[0]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -36,7 +36,7 @@ class TestCharm(unittest.TestCase):
         self.mock_machine = MagicMock()
         self.mock_machine.pull.return_value = ""
         self.mock_process = MagicMock()
-        self.mock_process.wait_output.return_value = (b"Flags: avx2 rdrand", "")
+        self.mock_process.wait_output.return_value = ("Flags: avx2 rdrand", "")
         self.mock_machine.exec.return_value = self.mock_process
         patch_machine.return_value = self.mock_machine
         self.mock_upf_network = MagicMock()
@@ -164,9 +164,9 @@ class TestCharm(unittest.TestCase):
         patch_network.return_value = self.mock_upf_network
 
         self.mock_process.wait_output.side_effect = [
-            (b"Flags: avx2 rdrand", ""),
-            (b"Flags: avx2 rdrand", ""),
-            (b"Flags: avx2 rdrand", ""),
+            ("Flags: avx2 rdrand", ""),
+            ("Flags: avx2 rdrand", ""),
+            ("Flags: avx2 rdrand", ""),
             ExecError(
                 command="configuration check",
                 exit_code=1,
@@ -194,8 +194,8 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
         upf_snap = MagicMock()
         self.mock_process.wait_output.side_effect = [
-            (b"Flags: avx2 rdrand", ""),
-            (b"Flags: avx2 rdrand", ""),
+            ("Flags: avx2 rdrand", ""),
+            ("Flags: avx2 rdrand", ""),
             ExecError(command="whatever", exit_code=1, stdout="", stderr=""),
         ]
         snap_cache = {"sdcore-upf": upf_snap}
@@ -462,7 +462,7 @@ class TestCharm(unittest.TestCase):
     def test_given_cpu_not_compatible_when_install_then_status_is_blocked(
         self, _
     ):
-        self.mock_process.wait_output.return_value = (b"Flags: ssse3 fma cx16 rdrand", "")
+        self.mock_process.wait_output.return_value = ("Flags: ssse3 fma cx16 rdrand", "")
         self.harness.set_leader(True)
         self.harness.charm.on.install.emit()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -36,7 +36,7 @@ class TestCharm(unittest.TestCase):
         self.mock_machine = MagicMock()
         self.mock_machine.pull.return_value = ""
         self.mock_process = MagicMock()
-        self.mock_process.wait_output.return_value = ("", "")
+        self.mock_process.wait_output.return_value = (b"Flags: avx2 rdrand", "")
         self.mock_machine.exec.return_value = self.mock_process
         patch_machine.return_value = self.mock_machine
         self.mock_upf_network = MagicMock()
@@ -164,7 +164,9 @@ class TestCharm(unittest.TestCase):
         patch_network.return_value = self.mock_upf_network
 
         self.mock_process.wait_output.side_effect = [
-            MagicMock(),
+            (b"Flags: avx2 rdrand", ""),
+            (b"Flags: avx2 rdrand", ""),
+            (b"Flags: avx2 rdrand", ""),
             ExecError(
                 command="configuration check",
                 exit_code=1,
@@ -456,6 +458,35 @@ class TestCharm(unittest.TestCase):
             ]
         )
         upf_snap.ensure.assert_called_with(SnapState.Absent)
+
+    @patch("charm.SnapCache")
+    def test_given_cpu_not_compatible_when_install_then_status_is_blocked(
+        self, _
+    ):
+        self.mock_process.wait_output.return_value = (b"Flags: ssse3 fma cx16 rdrand", "")
+        self.harness.set_leader(True)
+        self.harness.charm.on.install.emit()
+
+        self.harness.evaluate_status()
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ops.BlockedStatus("CPU is not compatible, see logs for more details"),
+        )
+
+    @patch("charm.SnapCache")
+    def test_given_cpu_compatible_when_install_then_status_is_active(
+        self, _
+    ):
+        self.harness.set_leader(True)
+        self.harness.charm.on.install.emit()
+
+        self.harness.evaluate_status()
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ops.ActiveStatus(),
+        )
 
 
 class TestCharmInitialisation(unittest.TestCase):


### PR DESCRIPTION
# Description

This PR aims to add CPU validation for the UPF machine charm. If the CPU does not support `avx2` and `rdrand` instructions, charm will go into blocked status.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
