### PR TITLE
fix: log route creation error and early stop configuration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -124,6 +124,9 @@ class SdcoreUpfCharm(ops.CharmBase):
             return
 
         self._network.configure()
+        if not self._network.is_configured():
+            return
+
         self._install_upf_snap()
         self._generate_upf_config_file()
         self._start_bessd_service()

--- a/src/upf_network.py
+++ b/src/upf_network.py
@@ -14,10 +14,6 @@ from pyroute2 import NDB, IPRoute, NetlinkError
 logger = logging.getLogger(__name__)
 
 
-class UPFNetworkError(Exception):
-    """Custom exception for UPFNetwork."""
-
-
 class NetworkInterface:
     """A class to interact with a network interface."""
 
@@ -184,11 +180,13 @@ class Route:
                 oif=self.oif,
                 priority=self.metric,
             )
+            logger.info(
+                "Route to %s via %s created/updated successfully",
+                self.destination,
+                self.gateway,
+            )
         except NetlinkError as e:
-            UPFNetworkError(f"Failed to create or replace the route: {e}")
-        logger.info(
-            "Route to %s via %s created/updated successfully", self.destination, self.gateway
-        )
+            logger.error("Failed to create or replace the route: %s", e.args)
 
     def delete(self) -> None:
         """Delete the route."""
@@ -200,11 +198,11 @@ class Route:
                 oif=self.oif,
                 priority=self.metric,
             )
+            logger.info(
+                "Route to %s via %s deleted successfully", self.destination, self.gateway
+            )
         except NetlinkError as e:
-            UPFNetworkError(f"Failed to delete the route: {e}")
-        logger.info(
-            "Route to %s via %s deleted successfully", self.destination, self.gateway
-        )
+            logger.error("Failed to create or replace the route: %s", e)
 
 
 class IPTablesRule:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -232,6 +232,18 @@ class TestCharm:
             "Network interfaces are not valid: ['eth0', 'eth1']"
         )
 
+    def test_given_network_not_configured_when_config_changed_then_snap_is_not_installed(self):
+        self.mock_upf_network.is_configured.return_value = False
+        upf_snap = MagicMock()
+        snap_cache = {"sdcore-upf": upf_snap}
+        self.mock_snap_cache.return_value = snap_cache
+
+        self.harness.charm.on.install.emit()
+
+        self.harness.evaluate_status()
+
+        upf_snap.ensure.assert_not_called()
+
     def test_given_network_interfaces_valid_when_config_changed_then_routes_are_created(self):
         gnb_subnet = "192.168.251.0/24"
 

--- a/tests/unit/test_upf_network.py
+++ b/tests/unit/test_upf_network.py
@@ -7,8 +7,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import iptc
 import pytest
-from pyroute2 import NetlinkError
-from upf_network import IPTablesRule, NetworkInterface, Route, UPFNetwork, UPFNetworkError
+from upf_network import IPTablesRule, NetworkInterface, Route, UPFNetwork
 
 
 class MockIPAddr:
@@ -365,12 +364,6 @@ class TestRoute:
             oif=self.oif,
             priority=self.metric,
         )
-
-    def given_netlink_error_when_create_then_exception_is_raised(self):
-        self.route.ip_route.route.side_effect = NetlinkError
-
-        with pytest.raises(UPFNetworkError):
-            self.route.create()
 
 
 class TestIPTablesRule:


### PR DESCRIPTION
# Description

This PR aims to fix #75.
Main changes:
* log route creation error instead of raising an exception (this avoids the `hook-failed`)
* early stop charm configuration if the full networking is not properly configured (addresses and routes)

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
