### PR TITLE
fix: Add base to terraform module to prevent placement error

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,6 +8,7 @@ resource "juju_application" "upf" {
   charm {
     name    = "sdcore-upf"
     channel = var.channel
+    base = "ubuntu@22.04"
   }
   config = var.config
   placement = var.machine_number


### PR DESCRIPTION
# Description

When trying the documentation in https://github.com/canonical/charmed-aether-sd-core/pull/17, I encountered the error:

```
juju_application.upf: Creating...
╷
│ Error: Client Error
│ 
│   with juju_application.upf,
│   on main.tf line 4, in resource "juju_application" "upf":
│    4: resource "juju_application" "upf" {
│ 
│ Unable to create application, got error: base from placements, "amd64/ubuntu/22.04/stable", does not match requested base "amd64"
```

After some research in issues related to placement with the juju provider, I tried adding the base in the module, and it fixed the error.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
