### PR TITLE
fix: make the interfaces up after configuration

### DIFF
--- a/src/upf_network.py
+++ b/src/upf_network.py
@@ -84,6 +84,7 @@ class NetworkInterface:
         interfaces = self.network_db.interfaces  # type: ignore[reportAttributeAccessIssue]
         if iface_record := interfaces.get(self.name):
             iface_record.set(state="up").commit()
+            return
         logger.warning(
             "Setting the interface state to up is failed: Interface %s not found in the network database",  # noqa: E501
             self.name,

--- a/src/upf_network.py
+++ b/src/upf_network.py
@@ -68,6 +68,21 @@ class NetworkInterface:
         logger.warning("Interface %s not found in the network database", self.name)
         return False
 
+    def interface_is_up(self) -> bool:
+        """Check if the given network interface is up."""
+        interfaces = self.network_db.interfaces  # type: ignore[reportAttributeAccessIssue]
+        if iface_record := interfaces.get(self.name):
+            return iface_record.state == "up"
+        logger.warning("Interface %s not found in the network database", self.name)
+        return False
+
+    def bring_up_interface(self) -> None:
+        """Set the network interface status to up."""
+        interfaces = self.network_db.interfaces  # type: ignore[reportAttributeAccessIssue]
+        if iface_record := interfaces.get(self.name):
+            iface_record.up()
+        logger.warning("Interface %s not found in the network database", self.name)
+
     def set_ip_address(self) -> None:
         """Clean all unrequired IPs and set the IP address for the given network interface."""
         interfaces = self.network_db.interfaces  # type: ignore[reportAttributeAccessIssue]
@@ -296,10 +311,14 @@ class UPFNetwork:
             self.access_interface.set_ip_address()
         if not self.access_interface.mtu_size_is_set():
             self.access_interface.set_mtu_size()
+        if not self.access_interface.interface_is_up():
+            self.access_interface.bring_up_interface()
         if not self.core_interface.addresses_are_set():
             self.core_interface.set_ip_address()
         if not self.core_interface.mtu_size_is_set():
             self.core_interface.set_mtu_size()
+        if not self.core_interface.interface_is_up():
+            self.core_interface.bring_up_interface()
         if not self.default_route.exists():
             logger.info("Default route does not exist")
             self.default_route.create()
@@ -321,7 +340,11 @@ class UPFNetwork:
             and self.ran_route.exists()
             and self.ip_tables_rule.exists()
         )
-        return ifaces_are_configured and routes_are_configured
+        interfaces_are_up = (
+            self.access_interface.interface_is_up()
+            and self.core_interface.interface_is_up()
+        )
+        return ifaces_are_configured and routes_are_configured and interfaces_are_up
 
     def clean_configuration(self) -> None:
         """Remove the configured IPs/routes from the networking."""

--- a/src/upf_network.py
+++ b/src/upf_network.py
@@ -72,7 +72,7 @@ class NetworkInterface:
         """Check if the given network interface is up."""
         interfaces = self.network_db.interfaces  # type: ignore[reportAttributeAccessIssue]
         if iface_record := interfaces.get(self.name):
-            return iface_record.state == "up"
+            return iface_record["state"] == "up"
         logger.warning("Interface %s not found in the network database", self.name)
         return False
 
@@ -80,7 +80,8 @@ class NetworkInterface:
         """Set the network interface status to up."""
         interfaces = self.network_db.interfaces  # type: ignore[reportAttributeAccessIssue]
         if iface_record := interfaces.get(self.name):
-            iface_record.up()
+            iface_record.set(state="up")
+            iface_record.commit()
         logger.warning("Interface %s not found in the network database", self.name)
 
     def set_ip_address(self) -> None:

--- a/src/upf_network.py
+++ b/src/upf_network.py
@@ -74,7 +74,7 @@ class NetworkInterface:
         if iface_record := interfaces.get(self.name):
             return iface_record["state"] == "up"
         logger.warning(
-            "Checking the state of network interface is failed: Interface %s not found in the network database",
+            "Checking the state of network interface is failed: Interface %s not found in the network database",  # noqa: E501
             self.name,
         )
         return False
@@ -85,7 +85,7 @@ class NetworkInterface:
         if iface_record := interfaces.get(self.name):
             iface_record.set(state="up").commit()
         logger.warning(
-            "Setting the interface state to up is failed: Interface %s not found in the network database",
+            "Setting the interface state to up is failed: Interface %s not found in the network database",  # noqa: E501
             self.name,
         )
 

--- a/src/upf_network.py
+++ b/src/upf_network.py
@@ -73,16 +73,21 @@ class NetworkInterface:
         interfaces = self.network_db.interfaces  # type: ignore[reportAttributeAccessIssue]
         if iface_record := interfaces.get(self.name):
             return iface_record["state"] == "up"
-        logger.warning("Interface %s not found in the network database", self.name)
+        logger.warning(
+            "Checking the state of network interface is failed: Interface %s not found in the network database",
+            self.name,
+        )
         return False
 
     def bring_up_interface(self) -> None:
         """Set the network interface status to up."""
         interfaces = self.network_db.interfaces  # type: ignore[reportAttributeAccessIssue]
         if iface_record := interfaces.get(self.name):
-            iface_record.set(state="up")
-            iface_record.commit()
-        logger.warning("Interface %s not found in the network database", self.name)
+            iface_record.set(state="up").commit()
+        logger.warning(
+            "Setting the interface state to up is failed: Interface %s not found in the network database",
+            self.name,
+        )
 
     def set_ip_address(self) -> None:
         """Clean all unrequired IPs and set the IP address for the given network interface."""

--- a/tests/unit/test_upf_network.py
+++ b/tests/unit/test_upf_network.py
@@ -36,6 +36,10 @@ class MockInterface:
         self.state = state
 
     def get(self, key):
+        return self.__getitem__(key)
+
+    def __getitem__(self, key):
+        """Return the given attribute from the interface."""
         return getattr(self, key)
 
 
@@ -1187,3 +1191,67 @@ class TestUPFNetwork:
 
         upf_network.configure()
         mock_core_interface_instance.set_mtu_size.assert_not_called()
+
+    def test_given_interfaces_are_down_when_configure_then_bring_up_interface_is_called_for_both_interfaces(self):  # noqa: E501
+        mock_access_interface_instance = MagicMock()
+        mock_access_interface_instance.is_valid.return_value = True
+        mock_access_interface_instance.addresses_are_set.return_value = True
+        mock_access_interface_instance.mtu_size_is_set.return_value = True
+        mock_access_interface_instance.interface_is_up.return_value = False
+        mock_core_interface_instance = MagicMock()
+        mock_core_interface_instance.is_valid.return_value = True
+        mock_core_interface_instance.addresses_are_set.return_value = True
+        mock_core_interface_instance.mtu_size_is_set.return_value = True
+        mock_core_interface_instance.interface_is_up.return_value = False
+        self.mock_network_interface.side_effect = [
+            mock_access_interface_instance,
+            mock_core_interface_instance,
+        ]
+        upf_network = UPFNetwork(
+            access_interface_name=self.access_interface_name,
+            access_ip=self.access_ip,
+            access_gateway_ip=self.access_gateway_ip,
+            access_mtu_size=self.access_interface_mtu_size,
+            core_interface_name=self.core_interface_name,
+            core_ip=self.core_ip,
+            core_gateway_ip=self.core_gateway_ip,
+            core_mtu_size=self.core_interface_mtu_size,
+            gnb_subnet=self.gnb_subnet,
+        )
+
+        upf_network.configure()
+
+        mock_access_interface_instance.bring_up_interface.assert_called_once()
+        mock_core_interface_instance.bring_up_interface.assert_called_once()
+
+    def test_given_interfaces_are_up_when_configure_then_bring_up_interface_is_not_called(self):
+        mock_access_interface_instance = MagicMock()
+        mock_access_interface_instance.is_valid.return_value = True
+        mock_access_interface_instance.addresses_are_set.return_value = True
+        mock_access_interface_instance.mtu_size_is_set.return_value = True
+        mock_access_interface_instance.interface_is_up.return_value = True
+        mock_core_interface_instance = MagicMock()
+        mock_core_interface_instance.is_valid.return_value = True
+        mock_core_interface_instance.addresses_are_set.return_value = True
+        mock_core_interface_instance.mtu_size_is_set.return_value = True
+        mock_core_interface_instance.interface_is_up.return_value = True
+        self.mock_network_interface.side_effect = [
+            mock_access_interface_instance,
+            mock_core_interface_instance,
+        ]
+        upf_network = UPFNetwork(
+            access_interface_name=self.access_interface_name,
+            access_ip=self.access_ip,
+            access_gateway_ip=self.access_gateway_ip,
+            access_mtu_size=self.access_interface_mtu_size,
+            core_interface_name=self.core_interface_name,
+            core_ip=self.core_ip,
+            core_gateway_ip=self.core_gateway_ip,
+            core_mtu_size=self.core_interface_mtu_size,
+            gnb_subnet=self.gnb_subnet,
+        )
+
+        upf_network.configure()
+
+        mock_access_interface_instance.bring_up_interface.assert_not_called()
+        mock_core_interface_instance.bring_up_interface.assert_not_called()

--- a/tests/unit/test_upf_network.py
+++ b/tests/unit/test_upf_network.py
@@ -23,11 +23,17 @@ class MockIPAddr:
 
 class MockInterface:
     def __init__(
-        self, name: str, ipv4_address: str = "", ipv6_address: str = "", mtu_size: int = 1500
+        self,
+        name: str,
+        ipv4_address: str = "",
+        ipv6_address: str = "",
+        mtu_size: int = 1500,
+        state: str = "down",
     ):
         self.name = name
         self.ipaddr = [MockIPAddr(ipv4_address=ipv4_address, ipv6_address=ipv6_address)]
         self.mtu = mtu_size
+        self.state = state
 
     def get(self, key):
         return getattr(self, key)
@@ -151,12 +157,29 @@ class TestNetworkInterface:
 
         assert address == self.interface_ipv4_address
 
+    def test_given_interface_status_is_up_when_get_interface_status_then_state_is_up(self):
+        self.network_interface.network_db.interfaces = MockInterfaces(
+            interfaces=[
+                MockInterface(
+                    ipv4_address=self.interface_ipv4_address,
+                    name=self.network_interface_name,
+                    state="up",
+                )
+            ]
+        )
+        assert self.network_interface.interface_is_up()
+
     def test_given_interface_doesnt_exist_when_get_interface_ip_address_then_empty_string_is_returned(self):  # noqa: E501
         self.network_interface.network_db.interfaces = MockInterfaces(interfaces=[])
 
         address = self.network_interface.get_ip_address()
 
         assert address == ""
+
+    def test_given_interface_doesnt_exist_when_check_interface_states_then_false_is_returned(self):  # noqa: E501
+        self.network_interface.network_db.interfaces = MockInterfaces(interfaces=[])
+
+        assert self.network_interface.interface_is_up() is False
 
     def test_given_interface_doesnt_have_ipv4_address_when_get_interface_ip_address_then_empty_string_is_returned(self):  # noqa: E501
         self.network_interface.network_db.interfaces = MockInterfaces(
@@ -1163,5 +1186,4 @@ class TestUPFNetwork:
         )
 
         upf_network.configure()
-
         mock_core_interface_instance.set_mtu_size.assert_not_called()


### PR DESCRIPTION
# Description
Fixes the `Network is unreachable` problem which is described below by making the interfaces up after UPF network configuration.
```
Env is an EC2 instance. Two additional interfaces attached for access and core.
Configuration passed to the charm included interface name, interface IP and gateway IP.
Network interfaces are configured correctly, but both are `DOWN`. 
Charm code should make sure that the interfaces have been brought UP after changing configuration.
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
