### PR TITLE
chore: Adds possibility of specifying the base of the charm in the Terraform module

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -23,9 +23,13 @@ depending on the deployment architecture.
 
 ### Pre-requisites
 
-- A host with a CPU supporting AVX2 and RDRAND instructions (Intel Haswell, AMD Excavator or equivalent)
-- Juju controller bootstrapped to a LXD cluster
-- A Juju machine representing the host that has been added to a model
+- A UPF host which meets or exceeds below requirements:
+  - Ubuntu 24.04
+  - CPU supporting AVX2 and RDRAND and PDPE1GB instructions (Intel Haswell, AMD Excavator or equivalent)
+- Juju host
+  - Juju>=3.4
+  - Cloud of type `manual` created
+  - UPF host machine added to Juju model
 - Terraform
 
 ### Deploying UPF with Terraform

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -25,7 +25,7 @@ depending on the deployment architecture.
 
 - A UPF host which meets or exceeds below requirements:
   - Ubuntu 24.04
-  - CPU supporting AVX2 and RDRAND and PDPE1GB instructions (Intel Haswell, AMD Excavator or equivalent)
+  - CPU supporting AVX2 and RDRAND instructions (Intel Haswell, AMD Excavator or equivalent)
 - Juju host
   - Juju>=3.4
   - Cloud of type `manual` created

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,7 +8,7 @@ resource "juju_application" "upf" {
   charm {
     name    = "sdcore-upf"
     channel = var.channel
-    base = "ubuntu@22.04"
+    base    = var.base
   }
   config = var.config
   placement = var.machine_number

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,7 +22,7 @@ variable "channel" {
 variable "base" {
   description = "The version of Ubuntu on the UPF host server. Currently supported values are `ubuntu@22.04` and `ubuntu@24.04`."
   type        = string
-  default     = "ubuntu@22.04"
+  default     = "ubuntu@24.04"
 }
 
 variable "config" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,6 +19,12 @@ variable "channel" {
   default     = "1.4/edge"
 }
 
+variable "base" {
+  description = "The version of Ubuntu on the UPF host server. Currently supported values are `ubuntu@22.04` and `ubuntu@24.04`."
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
 variable "config" {
   description = "Application config. Details about available options can be found at https://charmhub.io/sdcore-upf/configure."
   type        = map(string)


### PR DESCRIPTION
# Description

Adds possibility of specifying the base of the charm in the Terraform module. The default base is set to `ubuntu@24.04` because latest builds are targeted for this base. 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
