### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -4,7 +4,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import SdcoreUpfCharm
 
@@ -44,6 +44,6 @@ class UPFUnitTestFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=SdcoreUpfCharm,
         )

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -5,8 +5,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-import scenario
-from ops import ActiveStatus, BlockedStatus, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, WaitingStatus, testing
 
 from machine import ExecError
 from tests.unit.fixtures import UPFUnitTestFixtures
@@ -16,7 +15,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
     def test_given_unit_not_leader_when_collect_unit_status_then_status_is_blocked(
         self,
     ):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=False,
         )
 
@@ -44,7 +43,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
     def test_given_invalid_config_when_collect_unit_status_then_status_is_blocked(
         self, config_param, value
     ):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             config={
                 config_param: value,
@@ -60,7 +59,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
     def test_given_upf_mode_set_to_dpdk_and_hugepages_enabled_but_mac_addresses_of_access_and_core_interfaces_not_set_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
         self,
     ):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             config={"upf-mode": "dpdk"},
         )
@@ -75,7 +74,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
         self,
     ):
         self.mock_process.wait_output.return_value = ("Flags: ssse3 fma cx16 rdrand", "")
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -92,7 +91,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
             "eth0",
             "eth1",
         ]
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -106,7 +105,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
         self,
     ):
         self.mock_upf_network.get_invalid_network_interfaces.return_value = []
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
         self.mock_upf_network.is_configured.return_value = False
@@ -120,7 +119,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
     ):
         self.mock_upf_network.get_invalid_network_interfaces.return_value = []
         self.mock_machine.exists.return_value = False
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
         self.mock_upf_network.is_configured.return_value = True
@@ -140,7 +139,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
         }
         snap_cache = {"sdcore-upf": upf_snap}
         self.mock_snap_cache.return_value = snap_cache
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
         self.mock_upf_network.is_configured.return_value = True
@@ -169,7 +168,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
         }
         snap_cache = {"sdcore-upf": upf_snap}
         self.mock_snap_cache.return_value = snap_cache
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -190,7 +189,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
         }
         snap_cache = {"sdcore-upf": upf_snap}
         self.mock_snap_cache.return_value = snap_cache
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -212,7 +211,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
         }
         snap_cache = {"sdcore-upf": upf_snap}
         self.mock_snap_cache.return_value = snap_cache
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -234,7 +233,7 @@ class TestCharmCollectUnitStatus(UPFUnitTestFixtures):
         }
         snap_cache = {"sdcore-upf": upf_snap}
         self.mock_snap_cache.return_value = snap_cache
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -5,8 +5,8 @@
 import json
 from unittest.mock import MagicMock, call
 
-import scenario
 from charms.operator_libs_linux.v2.snap import SnapState
+from ops import testing
 
 from tests.unit.fixtures import UPFUnitTestFixtures
 
@@ -17,7 +17,7 @@ class TestCharmConfigure(UPFUnitTestFixtures):
     ):
         self.mock_upf_network.access_interface.exists.return_value = False
         self.mock_upf_network.core_interface.exists.return_value = False
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             config={
                 "upf-mode": "dpdk",
@@ -36,7 +36,7 @@ class TestCharmConfigure(UPFUnitTestFixtures):
     def test_given_leader_when_configure_then_network_is_configured(
         self,
     ):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -55,7 +55,7 @@ class TestCharmConfigure(UPFUnitTestFixtures):
         }
         snap_cache = {"sdcore-upf": upf_snap}
         self.mock_snap_cache.return_value = snap_cache
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -81,7 +81,7 @@ class TestCharmConfigure(UPFUnitTestFixtures):
         upf_snap.revision = "54"
         snap_cache = {"sdcore-upf": upf_snap}
         self.mock_snap_cache.return_value = snap_cache
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -93,7 +93,7 @@ class TestCharmConfigure(UPFUnitTestFixtures):
     def test_given_config_file_not_pushed_when_configure_then_config_file_is_pushed(
         self,
     ):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -111,7 +111,7 @@ class TestCharmConfigure(UPFUnitTestFixtures):
         with open("tests/unit/expected_upf.json", "r") as f:
             expected_config = f.read()
         self.mock_machine.pull.return_value = expected_config
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -130,7 +130,7 @@ class TestCharmConfigure(UPFUnitTestFixtures):
         }
         snap_cache = {"sdcore-upf": upf_snap}
         self.mock_snap_cache.return_value = snap_cache
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -155,7 +155,7 @@ class TestCharmConfigure(UPFUnitTestFixtures):
         }
         snap_cache = {"sdcore-upf": upf_snap}
         self.mock_snap_cache.return_value = snap_cache
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -166,11 +166,11 @@ class TestCharmConfigure(UPFUnitTestFixtures):
     def test_given_fiveg_n4_relation_when_configure_then_n4_information_published(
         self,
     ):
-        n4_relation = scenario.Relation(
+        n4_relation = testing.Relation(
             endpoint="fiveg_n4",
             interface="fiveg_n4",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[n4_relation],
         )

--- a/tests/unit/test_charm_remove.py
+++ b/tests/unit/test_charm_remove.py
@@ -4,8 +4,8 @@
 
 from unittest.mock import MagicMock, call
 
-import scenario
 from charms.operator_libs_linux.v2.snap import Snap
+from ops import testing
 
 from tests.unit.fixtures import UPFUnitTestFixtures
 
@@ -17,7 +17,7 @@ class TestCharmRemove(UPFUnitTestFixtures):
         upf_snap = MagicMock(spec=Snap)
         snap_cache = {"sdcore-upf": upf_snap}
         self.mock_snap_cache.return_value = snap_cache
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=False,
         )
 


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we use ops.testing instead of directly calling scenario. Both have the same API. scenario still needs to be independently installed.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
