### PR TITLE
fix: use correct parameters to export UPF metrics

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -47,10 +47,8 @@ class SdcoreUpfCharm(ops.CharmBase):
         self._machine = Machine()
         self._cos_agent = COSAgentProvider(
             self,
-            scrape_configs=[
-                {
-                    "static_configs": [{"targets": [f"*:{PROMETHEUS_PORT}"]}],
-                }
+            metrics_endpoints=[
+                {"path": "/metrics", "port": PROMETHEUS_PORT}
             ],
         )
         try:


### PR DESCRIPTION
# Description

This PR aims to fix an issue for which metrics provided by UPF could not be seen in COS Dashboard.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
